### PR TITLE
Flow definition YAML schema and starter templates

### DIFF
--- a/.flowchad/knowledge/flow-schema.md
+++ b/.flowchad/knowledge/flow-schema.md
@@ -1,0 +1,70 @@
+# Flow Definition YAML Schema
+
+Every flow lives in `.flowchad/flows/*.yml`. One file per flow.
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Human-readable flow name |
+| `url` | string | Starting URL (base or full) |
+| `steps` | list | Ordered steps to execute |
+
+## Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tags` | list | `[]` | Categorization tags for filtering |
+| `priority` | enum | `P1` | `P0` (critical), `P1` (important), `P2` (nice-to-have) |
+| `credentials` | map | `{}` | Env var references for auth (never hardcode) |
+| `headed` | bool | `false` | Force headed browser (delegates to Navvi if available) |
+
+## Step Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | enum | yes | `navigate`, `click`, `fill`, `select`, `scroll`, `wait`, `hover` |
+| `url` | string | for navigate | URL or path to navigate to |
+| `selector` | string | for click/fill/select/hover | CSS selector for target element |
+| `value` | string | for fill/select | Value to input or option to select |
+| `expect` | string | no | Human-readable expectation (AI evaluates against screenshot) |
+| `timing` | string | no | Max acceptable time (e.g. `2s`, `500ms`). Exceeding = friction |
+| `captcha` | bool | no | If `true`, delegates to Navvi for headed execution |
+| `optional` | bool | no | If `true`, step failure doesn't block the walk |
+
+## Actions Reference
+
+- **navigate** — go to URL. Requires `url`.
+- **click** — click element. Requires `selector`.
+- **fill** — type into input. Requires `selector` + `value`.
+- **select** — choose dropdown option. Requires `selector` + `value`.
+- **scroll** — scroll to element or direction. Optional `selector` (scrolls to it) or `value` (`top`/`bottom`/`down`).
+- **wait** — pause. Requires `value` (e.g. `2s`) or `selector` (wait until visible).
+- **hover** — hover over element. Requires `selector`.
+
+## Expect Evaluation
+
+The `expect` field is a natural language description, not a code assertion. The AI evaluates it against the screenshot and DOM state after the step completes.
+
+Examples:
+- `expect: form visible` — AI checks screenshot for a visible form
+- `expect: redirect to /dashboard` — AI checks URL changed to /dashboard
+- `expect: error message displayed` — AI looks for error UI
+- `expect: cart shows 3 items` — AI reads cart count from screenshot
+
+## Variable Substitution
+
+Use `$ENV_VAR` syntax for credentials and dynamic values:
+
+```yaml
+credentials:
+  email: $TEST_EMAIL
+  password: $TEST_PASSWORD
+
+steps:
+  - action: fill
+    selector: "#email"
+    value: $TEST_EMAIL
+```
+
+Variables are resolved from environment at walk time.

--- a/.flowchad/templates/checkout.yml
+++ b/.flowchad/templates/checkout.yml
@@ -1,0 +1,38 @@
+# Template: Checkout
+# Copy to .flowchad/flows/ and customize for your app.
+
+name: checkout
+url: https://staging.example.com
+tags: [payment, critical]
+priority: P0
+credentials:
+  email: $TEST_EMAIL
+  password: $TEST_PASSWORD
+
+steps:
+  - action: navigate
+    url: /cart
+    expect: cart page with items
+    timing: 2s
+
+  - action: click
+    selector: "[data-testid=checkout-button]"
+    expect: checkout form visible
+    timing: 2s
+
+  - action: fill
+    selector: "#card-number"
+    value: "4242424242424242"
+
+  - action: fill
+    selector: "#card-expiry"
+    value: "12/28"
+
+  - action: fill
+    selector: "#card-cvc"
+    value: "123"
+
+  - action: click
+    selector: "button[type=submit]"
+    expect: order confirmation page
+    timing: 5s

--- a/.flowchad/templates/login.yml
+++ b/.flowchad/templates/login.yml
@@ -1,0 +1,29 @@
+# Template: Login
+# Copy to .flowchad/flows/ and customize for your app.
+
+name: login
+url: https://staging.example.com
+tags: [auth, critical]
+priority: P0
+credentials:
+  email: $TEST_EMAIL
+  password: $TEST_PASSWORD
+
+steps:
+  - action: navigate
+    url: /login
+    expect: login form visible
+    timing: 2s
+
+  - action: fill
+    selector: "#email"
+    value: $TEST_EMAIL
+
+  - action: fill
+    selector: "#password"
+    value: $TEST_PASSWORD
+
+  - action: click
+    selector: "button[type=submit]"
+    expect: redirect to /dashboard
+    timing: 3s

--- a/.flowchad/templates/onboarding.yml
+++ b/.flowchad/templates/onboarding.yml
@@ -1,0 +1,36 @@
+# Template: Onboarding
+# Copy to .flowchad/flows/ and customize for your app.
+
+name: onboarding
+url: https://staging.example.com
+tags: [onboarding, activation]
+priority: P1
+credentials:
+  email: $TEST_EMAIL
+  password: $TEST_PASSWORD
+
+steps:
+  - action: navigate
+    url: /welcome
+    expect: onboarding wizard or welcome screen
+    timing: 2s
+
+  - action: click
+    selector: "[data-testid=get-started]"
+    expect: first onboarding step
+    timing: 2s
+
+  - action: fill
+    selector: "#company-name"
+    value: "Test Company"
+
+  - action: click
+    selector: "[data-testid=next-step]"
+    expect: second onboarding step
+    timing: 2s
+
+  - action: click
+    selector: "[data-testid=skip]"
+    expect: dashboard or main app screen
+    timing: 3s
+    optional: true

--- a/.flowchad/templates/sign-up.yml
+++ b/.flowchad/templates/sign-up.yml
@@ -1,0 +1,29 @@
+# Template: Sign Up
+# Copy to .flowchad/flows/ and customize for your app.
+
+name: sign-up
+url: https://staging.example.com
+tags: [onboarding, critical]
+priority: P0
+credentials:
+  email: $TEST_EMAIL
+  password: $TEST_PASSWORD
+
+steps:
+  - action: navigate
+    url: /signup
+    expect: registration form visible
+    timing: 2s
+
+  - action: fill
+    selector: "#email"
+    value: $TEST_EMAIL
+
+  - action: fill
+    selector: "#password"
+    value: $TEST_PASSWORD
+
+  - action: click
+    selector: "button[type=submit]"
+    expect: redirect to /dashboard or confirmation page
+    timing: 3s


### PR DESCRIPTION
## Summary
- `knowledge/flow-schema.md` — full schema reference: actions, selectors, expect (natural language, AI-evaluated), timing, credentials, variable substitution
- 4 starter templates: sign-up, login, checkout, onboarding
- Templates go in `templates/`, users copy to `flows/` and customize

Closes #3