### PR TITLE
Walk and report skills — P1 MVP loop

### DIFF
--- a/.flowchad/commands/flow-report.md
+++ b/.flowchad/commands/flow-report.md
@@ -1,0 +1,12 @@
+---
+description: Generate a friction report from walk results — Critical/Friction/Cosmetic with actionable fixes
+disable-model-invocation: false
+---
+
+Generate a friction report for the flow specified by $ARGUMENTS using the flow-report skill.
+
+1. Find the most recent snapshot for the flow in `.flowchad/snapshots/`
+2. If no snapshot exists, suggest running `/flow-walk $ARGUMENTS` first
+3. Analyze results and screenshots following the flow-report skill instructions
+4. Save report to `.flowchad/reports/`
+5. Print the full report

--- a/.flowchad/commands/flow-walk.md
+++ b/.flowchad/commands/flow-walk.md
@@ -1,0 +1,12 @@
+---
+description: Walk a user flow — execute steps via Playwright, capture screenshots, measure timing
+disable-model-invocation: false
+---
+
+Walk the flow specified by $ARGUMENTS using the flow-walk skill.
+
+1. Load the flow definition from `.flowchad/flows/$ARGUMENTS.yml`
+2. If the file doesn't exist, list available flows and ask which one to walk
+3. Execute the walk following the flow-walk skill instructions
+4. Store results in `.flowchad/snapshots/`
+5. Print the summary

--- a/.flowchad/skills/flow-report/SKILL.md
+++ b/.flowchad/skills/flow-report/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: flow-report
+description: Generate a categorized friction report from walk results — Critical/Friction/Cosmetic findings with actionable suggestions. Usage /flow-report <flow-name>
+user_invocable: true
+---
+
+# Flow Report
+
+Analyze walk results and generate a categorized friction report.
+
+## Usage
+
+```
+/flow-report sign-up
+/flow-report login
+```
+
+The argument is the flow name. Uses the most recent snapshot for that flow.
+
+## Inputs
+
+1. **Walk results** — load `snapshots/{latest}-{flow-name}/results.json`
+2. **Screenshots** — read each step screenshot for visual analysis
+3. **Flow definition** — load `flows/{flow-name}.yml` for context
+4. **Knowledge docs** — reference `knowledge/friction-taxonomy.md` for severity classification
+5. **Config** — load `config.yml` for platform type, timing thresholds, business goals
+
+## Analysis Process
+
+### 1. Load Data
+
+Find the most recent snapshot directory matching the flow name:
+```bash
+ls -d .flowchad/snapshots/*-{flow-name} | sort -r | head -1
+```
+
+Read `results.json` and all screenshots from that directory.
+
+### 2. Classify Each Finding
+
+For every step that isn't a clean pass, classify using `knowledge/friction-taxonomy.md`:
+
+**Critical** — user cannot complete the task:
+- Step status is `error` or `fail` on a non-optional step
+- Navigation failure (page didn't load)
+- Form submission returned server error
+- Redirect loop or dead end
+
+**Friction** — user can complete but experience is painful:
+- Step flagged as `slow` (exceeded timing threshold)
+- Expect partially met (page loaded but content wrong)
+- Extra steps needed that aren't in the flow (unexpected modal, cookie banner)
+- Confusing UI observed in screenshot
+
+**Cosmetic** — works fine but looks rough:
+- Minor visual issues spotted in screenshots
+- Alignment, spacing, contrast problems
+- Truncated text, placeholder text visible
+
+### 3. Consider Platform Type
+
+Reference `knowledge/platform-types.md` and `config.yml`:
+- **SaaS**: prioritize onboarding/activation friction
+- **Website**: prioritize page load speed, mobile, SEO
+- **Internal tool**: prioritize efficiency, error handling
+- **Mobile**: prioritize touch targets, viewport, orientation
+
+### 4. Generate Suggestions
+
+For each finding, provide:
+- **What's wrong** — specific observation
+- **Why it matters** — impact on user/business
+- **Suggested fix** — concrete, actionable recommendation
+- **Effort estimate** — low / medium / high
+
+### 5. Cross-Reference Speckit (if available)
+
+If `.speckit/` exists in the project, check:
+- Does the observed behavior match the spec?
+- Flag spec violations as separate findings
+- Note if a spec is missing for a critical flow
+
+## Output
+
+Generate a markdown report at:
+```
+.flowchad/reports/{YYYY-MM-DD}-{flow-name}-report.md
+```
+
+### Report Template
+
+```markdown
+# Friction Report: {Flow Name}
+
+**Date:** {timestamp}
+**Flow:** {flow-name}
+**URL:** {base_url}
+**Pass rate:** {passed}/{total} steps ({pass_rate}%)
+**Duration:** {total_duration}
+
+---
+
+## Critical
+
+### 1. {Title}
+**Step {N}:** {action} → {target}
+**Observed:** {what happened}
+**Expected:** {what should happen}
+**Impact:** {why this matters}
+**Fix:** {suggested fix}
+**Effort:** {low|medium|high}
+**Screenshot:** {path}
+
+---
+
+## Friction
+
+### 2. {Title}
+...
+
+---
+
+## Cosmetic
+
+### 3. {Title}
+...
+
+---
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Critical | N |
+| Friction | N |
+| Cosmetic | N |
+
+**Overall assessment:** {one-line verdict}
+
+**Recommended next steps:**
+1. {highest priority fix}
+2. {second priority}
+3. {third priority}
+```
+
+## After Report
+
+Print the report to the user and note the saved path. Suggest:
+- "Run `/flow-walk {name}` again after fixes to track improvement"
+- "Run `/flow-suggest {name}` for AI-prioritized improvement plan" (once suggest skill exists)

--- a/.flowchad/skills/flow-walk/SKILL.md
+++ b/.flowchad/skills/flow-walk/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: flow-walk
+description: Walk a user flow using Playwright CDP — execute steps, capture screenshots, measure timing, store results. Usage /flow-walk <flow-name>
+user_invocable: true
+---
+
+# Flow Walk
+
+Execute a flow definition step-by-step using Playwright CDP, capturing screenshots and timing at each step.
+
+## Usage
+
+```
+/flow-walk sign-up
+/flow-walk login
+/flow-walk checkout
+```
+
+The argument is the flow name (matches `flows/{name}.yml`).
+
+## Prerequisites
+
+- Chromium or Chrome running with CDP enabled, OR launch headless
+- Playwright-core installed (`npm i -g playwright-core` or local)
+- Flow definition in `.flowchad/flows/{name}.yml`
+
+## Execution
+
+### Step 0: Load Flow & Connect Browser
+
+```javascript
+// Launch or connect to browser
+// Prefer CDP connection if Chrome is already running on port 9222
+// Otherwise launch headless Chromium via playwright
+import { chromium } from 'playwright-core';
+
+// Try CDP first, fall back to launch
+let browser;
+try {
+  browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+} catch {
+  browser = await chromium.launch({ headless: true });
+}
+```
+
+Load the flow YAML from `.flowchad/flows/{name}.yml`. Parse steps. Resolve `$ENV_VAR` references from environment.
+
+### Step 1: Execute Each Step
+
+For each step in the flow:
+
+1. **Perform the action:**
+   - `navigate` → `page.goto(url)`
+   - `click` → `page.click(selector)`
+   - `fill` → `page.fill(selector, value)`
+   - `select` → `page.selectOption(selector, value)`
+   - `scroll` → `page.evaluate(() => window.scrollTo(...))`  or scroll to selector
+   - `wait` → `page.waitForSelector(selector)` or `page.waitForTimeout(ms)`
+   - `hover` → `page.hover(selector)`
+
+2. **Measure timing** — record `Date.now()` before and after action
+
+3. **Take screenshot** — `page.screenshot({ path: snapshotDir/step-{N}-{action}.png, fullPage: false })`
+
+4. **Evaluate expect** — this is the key AI step:
+   - Read the `expect` string from the YAML (natural language)
+   - Look at the screenshot and current page URL/DOM
+   - Determine if the expectation is met
+   - Record as `pass`, `fail`, or `error`
+
+5. **Check timing threshold** — if `timing` is specified and actual > threshold, flag as `slow`
+
+### Step 2: Handle Errors
+
+**A broken step is a finding, not a failure.** If a step throws:
+- Catch the error
+- Take a screenshot of the current state
+- Log the error message
+- Record status as `error`
+- **Continue to the next step** (unless it's a navigation failure that blocks everything)
+
+If a step has `optional: true` and fails, record but don't flag as critical.
+
+If a step has `captcha: true`, skip with status `skipped` and note "requires headed browser (Navvi)".
+
+### Step 3: Store Results
+
+Create a dated snapshot directory:
+
+```
+.flowchad/snapshots/
+└── {YYYY-MM-DD}-{flow-name}/
+    ├── step-01-navigate.png
+    ├── step-02-fill.png
+    ├── step-03-fill.png
+    ├── step-04-click.png
+    └── results.json
+```
+
+### results.json Schema
+
+```json
+{
+  "flow": "sign-up",
+  "timestamp": "2026-03-20T15:30:00-03:00",
+  "duration_ms": 8500,
+  "config": {
+    "url": "https://staging.example.com",
+    "headless": true
+  },
+  "steps": [
+    {
+      "index": 1,
+      "action": "navigate",
+      "target": "/signup",
+      "status": "pass",
+      "timing_ms": 1200,
+      "threshold_ms": 2000,
+      "slow": false,
+      "screenshot": "step-01-navigate.png",
+      "expect": "registration form visible",
+      "expect_met": true
+    },
+    {
+      "index": 2,
+      "action": "fill",
+      "target": "#email",
+      "status": "pass",
+      "timing_ms": 150,
+      "screenshot": "step-02-fill.png"
+    }
+  ],
+  "summary": {
+    "total": 4,
+    "passed": 3,
+    "failed": 1,
+    "errors": 0,
+    "skipped": 0,
+    "slow": 1,
+    "pass_rate": 0.75
+  }
+}
+```
+
+## Output
+
+After the walk completes, print a summary:
+
+```
+## Flow Walk: sign-up
+
+✓ step 1: navigate /signup (1.2s)
+✓ step 2: fill #email (0.15s)
+✗ step 3: fill #password — element not found
+✓ step 4: click submit (2.8s) ⚠️ slow (threshold: 2s)
+
+Results: 3/4 passed, 1 slow
+Snapshot: .flowchad/snapshots/2026-03-20-sign-up/
+```
+
+Then suggest: "Run `/flow-report sign-up` to generate a friction report from these results."


### PR DESCRIPTION
## Summary
Two skills + two slash commands that form the MVP loop:

**Walk skill (`/flow-walk <name>`):**
- Executes flow steps via Playwright CDP
- Screenshots each step, measures timing
- Evaluates `expect` conditions (natural language, AI-judged)
- Broken steps = findings, not failures — walk continues
- Stores results.json + screenshots in dated snapshot dirs

**Report skill (`/flow-report <name>`):**
- Loads most recent walk snapshot
- Classifies findings as Critical / Friction / Cosmetic (per friction taxonomy)
- Cross-references platform type, timing thresholds, speckit specs
- Generates actionable markdown report with fix suggestions + effort estimates
- Saves to `.flowchad/reports/`

Closes #4, closes #5