### PR TITLE
feat: auto-discover i18n config and store locales in flow YAML (fixes #31)

### DIFF
--- a/.flowchad/config.yml
+++ b/.flowchad/config.yml
@@ -50,6 +50,12 @@
 #     deploy_check: vercel
 #     deploy_timeout: 120
 
+# Locales (auto-detected by /flowchad-setup — do not edit manually)
+# Run /flowchad-setup to refresh after i18n config changes.
+# [en] = English-only site, no locale-prefixed paths.
+# [en, es] = generates /es/* paths for flows when walking locale-aware routes.
+# locales: [en]
+
 # Navvi persona (optional — enables authenticated flow walks)
 # Gopass entry: navvi/{persona}/email and navvi/{persona}/password
 # Used for flows that require login, form submissions, email verification.

--- a/.flowchad/knowledge/flow-schema.md
+++ b/.flowchad/knowledge/flow-schema.md
@@ -21,6 +21,7 @@ Every flow lives in `.flowchad/flows/*.yml`. One file per flow.
 | `headed` | bool | `false` | Force headed browser (delegates to Navvi if available) |
 | `video` | bool | `true` | Record video of the walk (requires ffmpeg for trimming) |
 | `viewport` | map | `{width: 1280, height: 720}` | Browser viewport size |
+| `locales` | list | `[en]` | Confirmed locales for this flow (auto-detected by `/flowchad-setup`). Flow walk only generates locale-prefixed paths for locales in this list. `[en]` means no prefix (English-only site). See [i18n locale detection](#i18n-locale-detection). |
 
 ## Step Fields
 
@@ -119,3 +120,36 @@ steps:
 ```
 
 Variables are resolved from environment at walk time.
+
+## i18n Locale Detection
+
+The `locales` field tells flow-walk which locale prefixes are valid for this project. It is auto-populated by `/flowchad-setup` via `scripts/detect-i18n.sh` and should be updated whenever the site's i18n config changes (re-run `/flowchad-setup` to refresh).
+
+### Detection priority (first match wins)
+
+1. **Next.js** — `i18n.locales` array in `next.config.{js,mjs,ts,cjs}`
+2. **locales/ or messages/ directories** — subdirectory names or top-level JSON/YAML filenames (used by next-intl, i18next, react-intl, etc.)
+3. **Strapi** — i18n plugin detection (locales stored in DB; falls through to hreflang check)
+4. **hreflang tags** — `<link rel="alternate" hreflang=...>` scraped from the production homepage URL in `config.yml`
+5. **Default** — `[en]` (English only, no locale prefix)
+
+### Behavior in flow-walk
+
+- `locales: [en]` → test routes as-is (e.g., `/login`, `/signup`). **No `/en/` prefix.**
+- `locales: [en, es]` → test both `/login` (en) and `/es/login` (es) variants.
+- `locales: [en, es, fr]` → test three variants per locale-aware route.
+
+Only routes that naturally include a locale prefix in the flow definition (e.g., `url: /es/login`) are affected. Routes already hardcoded with a locale are used as-is.
+
+### Example
+
+```yaml
+# English-only site — no locale-prefixed routes generated
+locales: [en]
+
+# Multilingual site confirmed by next.config.js i18n block
+locales: [en, es]
+
+# Three-locale site detected from messages/ directory
+locales: [en, es, fr]
+```

--- a/.flowchad/skills/flow-add/SKILL.md
+++ b/.flowchad/skills/flow-add/SKILL.md
@@ -73,6 +73,15 @@ grep -ri "test.*email\|test.*password\|seed\|fixture" .env.example .env.test 2>/
 cat .flowchad/config.yml 2>/dev/null | grep -A2 credentials
 ```
 
+### 2e. Read locales from config
+
+```bash
+# Read confirmed locales — set by /flowchad-setup via i18n detection
+grep '^locales:' .flowchad/config.yml 2>/dev/null || echo "locales: [en]"
+```
+
+Use the `locales` value from `config.yml` in the generated flow. If not set, default to `[en]`.
+
 ## Step 3: Draft Flow YAML
 
 Generate the flow definition following the naming convention:
@@ -132,6 +141,7 @@ name: New user signs up with Google OAuth and lands on the onboarding wizard
 url: https://staging.example.com
 tags: [onboarding, auth, oauth]
 priority: P0
+locales: [en]  # from config.yml — [en, es] if site has confirmed i18n
 context:
   user: new_account
   auth: logged_out

--- a/.flowchad/skills/flow-walk/SKILL.md
+++ b/.flowchad/skills/flow-walk/SKILL.md
@@ -45,6 +45,20 @@ try {
 
 Load the flow YAML from `.flowchad/flows/{name}.yml`. Parse steps. Resolve `$ENV_VAR` references from environment.
 
+**i18n locale check:** read the `locales` field from the flow YAML (falls back to `config.yml` then defaults to `[en]`).
+
+- `locales: [en]` — walk routes as-is. Never prefix with `/en/` or any other locale.
+- `locales: [en, es]` — for each step with a relative `url`, walk the base path (en) then the `/es/` prefixed path (es). Report results per locale.
+- Only generate locale-prefixed paths for locales **explicitly listed** in `locales`. Do not infer locale support from URL patterns alone.
+
+```bash
+# Read locales for this flow
+FLOW_LOCALES=$(grep '^locales:' ".flowchad/flows/${FLOW_NAME}.yml" 2>/dev/null \
+  || grep '^locales:' ".flowchad/config.yml" 2>/dev/null \
+  || echo "locales: [en]")
+# e.g. "locales: [en, es]" → parse to array ["en", "es"]
+```
+
 ### Step 0b: Start Video Recording
 
 If the flow has `video: false`, skip this step. Otherwise, start recording:

--- a/.flowchad/skills/flowchad-setup/SKILL.md
+++ b/.flowchad/skills/flowchad-setup/SKILL.md
@@ -80,7 +80,27 @@ grep -r "app\.\(get\|post\|put\|delete\|route\)" --include="*.ts" --include="*.j
   src/ routes/ 2>/dev/null | head -20
 ```
 
-### 1e. Detect Dev Server, URLs & Credentials
+### 1e. Detect i18n Configuration
+
+Run `scripts/detect-i18n.sh` (relative to the project root) to auto-detect supported locales:
+
+```bash
+bash scripts/detect-i18n.sh .
+# Output: space-separated locale codes, e.g. "en" or "en es fr"
+```
+
+The script checks (in order, first match wins):
+1. **Next.js** — `i18n.locales` array in `next.config.{js,mjs,ts,cjs}`
+2. **locales/ or messages/ directories** — subdirectory names or top-level JSON/YAML filenames
+3. **Strapi** — i18n plugin detection (falls through if locales are DB-only)
+4. **hreflang tags** — `<link rel="alternate" hreflang=...>` scraped from `config.yml` base URL
+5. **Default** — `en` (no locale prefix)
+
+Store result as `$DETECTED_LOCALES` (e.g., `"en"` or `"en es"`). Convert to YAML list format: `[en]` or `[en, es]`.
+
+**On re-run (existing config.yml):** compare detected locales to the current `locales:` field. If changed, update the field and all existing flows in `.flowchad/flows/*.yml`.
+
+### 1f. Detect Dev Server, URLs & Credentials
 
 FlowChad is designed to run against the local dev server first. Detect the dev server command and URLs in priority order: **localhost > staging > production**.
 
@@ -125,6 +145,7 @@ Present a summary:
 **Speckit:** [installed / not found]
 **Routes:** N public routes detected
 **Test credentials:** [found in fixtures / not found]
+**i18n locales:** [en] (English-only) | [en, es, ...] (detected from {source})
 ```
 
 Then ask ONLY what's missing. **URL priority is localhost > staging > production** — FlowChad runs against the local dev server by default:
@@ -160,6 +181,10 @@ credentials:
 analytics:
   provider: {mixpanel|posthog|none}
   mcp: true
+
+# Detected by /flowchad-setup via scripts/detect-i18n.sh
+# [en] = English-only site. [en, es] = locale-prefixed routes exist for /es/*.
+locales: [{detected_locales_csv}]
 ```
 
 ### Convert Existing Tests to Flow Definitions
@@ -179,6 +204,7 @@ name: New user signs up with email and password and lands on the dashboard
 url: {start_url}
 tags: [{category}]
 priority: P0
+locales: [{detected_locales_csv}]  # from scripts/detect-i18n.sh
 context:
   user: new_account
   auth: logged_out
@@ -200,6 +226,7 @@ name: Visitor loads the homepage and sees the hero section with CTA
 url: {route_path}
 tags: [auto-generated]
 priority: P2
+locales: [{detected_locales_csv}]  # from scripts/detect-i18n.sh
 context:
   user: anonymous
   auth: logged_out
@@ -254,6 +281,10 @@ Created:
 - .flowchad/config.yml (updated)
 - .flowchad/flows/ — {N} flow definitions
 - .mcp.json updated with {analytics_provider} (if applicable)
+
+i18n: detected locales [{detected_locales_csv}] from {source}.
+      Flow walk will only generate /{locale}/* paths for confirmed locales.
+      Re-run /flowchad-setup to refresh if i18n config changes.
 
 Next steps:
 1. Review generated flows in .flowchad/flows/

--- a/.flowchad/templates/checkout.yml
+++ b/.flowchad/templates/checkout.yml
@@ -7,6 +7,7 @@ name: Logged-in user checks out their cart with a credit card and sees order con
 url: https://staging.example.com
 tags: [payment, critical]
 priority: P0
+locales: [en]  # auto-detected by /flowchad-setup — update if site adds i18n
 context:
   user: existing
   auth: logged_in

--- a/.flowchad/templates/login.yml
+++ b/.flowchad/templates/login.yml
@@ -7,6 +7,7 @@ name: Existing user logs in with email and password and reaches the dashboard
 url: https://staging.example.com
 tags: [auth, critical]
 priority: P0
+locales: [en]  # auto-detected by /flowchad-setup — update if site adds i18n
 context:
   user: existing
   auth: logged_out

--- a/.flowchad/templates/onboarding.yml
+++ b/.flowchad/templates/onboarding.yml
@@ -7,6 +7,7 @@ name: New user completes onboarding wizard after sign-up and reaches the main da
 url: https://staging.example.com
 tags: [onboarding, activation]
 priority: P1
+locales: [en]  # auto-detected by /flowchad-setup — update if site adds i18n
 context:
   user: new_account
   auth: logged_in

--- a/.flowchad/templates/sign-up.yml
+++ b/.flowchad/templates/sign-up.yml
@@ -7,6 +7,7 @@ name: New user signs up with email and password and lands on the dashboard
 url: https://staging.example.com
 tags: [onboarding, critical]
 priority: P0
+locales: [en]  # auto-detected by /flowchad-setup — update if site adds i18n
 context:
   user: new_account
   auth: logged_out

--- a/scripts/detect-i18n.sh
+++ b/scripts/detect-i18n.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Detect i18n configuration and print supported locales to stdout.
+# Output: space-separated locale codes, e.g. "en" or "en es fr"
+# Exit 0 always; defaults to "en" if no i18n detected.
+
+set -euo pipefail
+
+PROJECT_DIR="${1:-.}"
+DETECTED_LOCALES=""
+
+# ── 1. Next.js i18n block in next.config.{js,mjs,ts,cjs} ──────────────────
+for cfg in \
+  "$PROJECT_DIR/next.config.js" \
+  "$PROJECT_DIR/next.config.mjs" \
+  "$PROJECT_DIR/next.config.ts" \
+  "$PROJECT_DIR/next.config.cjs"; do
+  if [ -f "$cfg" ]; then
+    # Extract locales array: i18n: { locales: ['en', 'es', 'fr'] }
+    locales=$(grep -A5 'i18n' "$cfg" 2>/dev/null \
+      | grep -oP "(?<=locales:\s*\[)[^\]]*" \
+      | tr -d "'" | tr -d '"' | tr ',' ' ' | tr -s ' ' | sed 's/^ //;s/ $//' \
+      2>/dev/null || true)
+    if [ -n "$locales" ]; then
+      DETECTED_LOCALES="$locales"
+      break
+    fi
+  fi
+done
+
+# ── 2. locales/ or messages/ directory (next-intl, i18next, etc.) ──────────
+if [ -z "$DETECTED_LOCALES" ]; then
+  for dir in "$PROJECT_DIR/locales" "$PROJECT_DIR/messages" "$PROJECT_DIR/public/locales" "$PROJECT_DIR/src/locales"; do
+    if [ -d "$dir" ]; then
+      # Subdirectory names are locale codes (en, es, fr-FR, etc.)
+      subdirs=$(ls -1 "$dir" 2>/dev/null | grep -E '^[a-z]{2}(-[A-Z]{2})?$' | tr '\n' ' ' | sed 's/ $//' || true)
+      if [ -n "$subdirs" ]; then
+        DETECTED_LOCALES="$subdirs"
+        break
+      fi
+      # JSON/YAML files at top level (en.json, es.json)
+      files=$(ls -1 "$dir"/*.json "$dir"/*.yml "$dir"/*.yaml 2>/dev/null \
+        | xargs -I{} basename {} \
+        | grep -oE '^[a-z]{2}(-[A-Z]{2})?' \
+        | sort -u | tr '\n' ' ' | sed 's/ $//' || true)
+      if [ -n "$files" ]; then
+        DETECTED_LOCALES="$files"
+        break
+      fi
+    fi
+  done
+fi
+
+# ── 3. Strapi: locale content types (admin/src/extensions or api/) ─────────
+if [ -z "$DETECTED_LOCALES" ]; then
+  if grep -r '"i18n"\|"locale"' "$PROJECT_DIR/config" 2>/dev/null | grep -q 'enabled.*true\|true.*enabled'; then
+    # Strapi with i18n plugin enabled — locales stored in DB, can't auto-detect
+    # Fall through to hreflang check
+    :
+  fi
+fi
+
+# ── 4. <link rel="alternate" hreflang=...> on production homepage ──────────
+if [ -z "$DETECTED_LOCALES" ]; then
+  # Try to find base URL from .flowchad/config.yml
+  BASE_URL=""
+  if [ -f "$PROJECT_DIR/.flowchad/config.yml" ]; then
+    BASE_URL=$(grep -E '^url:' "$PROJECT_DIR/.flowchad/config.yml" 2>/dev/null \
+      | head -1 | sed 's/url: *//' | tr -d '"' | tr -d "'" | sed 's/ *#.*//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
+  fi
+  if [ -n "$BASE_URL" ]; then
+    hreflang=$(curl -s --max-time 5 "$BASE_URL" 2>/dev/null \
+      | grep -oP 'hreflang="[^"]+"' \
+      | grep -oP '(?<=hreflang=")[^"]+' \
+      | grep -v 'x-default' \
+      | sort -u | tr '\n' ' ' | sed 's/ $//' || true)
+    if [ -n "$hreflang" ]; then
+      DETECTED_LOCALES="$hreflang"
+    fi
+  fi
+fi
+
+# ── Output ─────────────────────────────────────────────────────────────────
+if [ -z "$DETECTED_LOCALES" ]; then
+  echo "en"
+else
+  echo "$DETECTED_LOCALES"
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/detect-i18n.sh` — probes 4 sources in priority order (Next.js config → locales/messages dirs → Strapi i18n → hreflang tags on homepage) and outputs confirmed locale codes, defaulting to `en` if nothing is found
- Adds `locales` field to all flow templates (`login`, `sign-up`, `onboarding`, `checkout`)
- Updates `/flowchad-setup` skill: Phase 1e now runs i18n detection, Phase 3 writes `locales` into `config.yml` and stamps every generated flow YAML; re-runs update existing flows if locales changed
- Updates `/flow-add` skill: reads `locales` from `config.yml` when creating new flows
- Updates `/flow-walk` skill: only generates `/{locale}/*` test paths for locales **explicitly listed** in the flow's `locales` field — preventing false-positive P0 issues on English-only sites
- Updates `flow-schema.md` with full `locales` field documentation and i18n behavior spec

## How detection works

```
scripts/detect-i18n.sh [project-dir]
```

1. **Next.js** — parses `i18n.locales` array in `next.config.{js,mjs,ts,cjs}`
2. **locales/ or messages/ directories** — reads subdirectory names or top-level JSON/YAML filenames
3. **Strapi** — detects i18n plugin (falls through to hreflang if locales are DB-only)
4. **hreflang tags** — `curl`s the base URL from `config.yml` and extracts `hreflang` attribute values
5. **Default** — `en` (English-only, no prefix)

## Example flow YAML output

```yaml
name: Existing user logs in with email and password and reaches the dashboard
url: https://staging.example.com
tags: [auth, critical]
priority: P0
locales: [en]           # English-only site — no /en/ prefix ever generated
context:
  user: existing
  auth: logged_out
```

For a multilingual site:
```yaml
locales: [en, es]       # /login tested + /es/login tested
```

## Fixes

Closes [fellowship-dev/flowchad#31](https://github.com/fellowship-dev/flowchad/issues/31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)