### PR TITLE
feat: verify production impact before assigning severity (issue #32)

### DIFF
--- a/.flowchad/skills/flow-report/SKILL.md
+++ b/.flowchad/skills/flow-report/SKILL.md
@@ -148,6 +148,127 @@ Generate a markdown report at:
 3. {third priority}
 ```
 
+## File Issues for Critical Findings
+
+For every Critical finding in the report, file a GitHub issue. Before assigning P0/P1, **verify whether production is actually affected**.
+
+### Step 1: Resolve the Production URL
+
+Check in priority order:
+
+1. `config.yml` → `environments.production.url`
+2. `BRIEF.md` in the project root — grep for `production:` or `prod:` URL
+3. `gh api /repos/{owner}/{repo} --jq .homepage` (GitHub repo homepage field)
+4. If all fail, mark as `UNKNOWN`
+
+```bash
+# Detect repo
+REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|')
+
+# Try GitHub homepage as last resort
+gh api "/repos/${REPO}" --jq '.homepage // empty' 2>/dev/null
+```
+
+### Step 2: Determine if a Production Check Is Needed
+
+Extract the base URL from `results.json` → `config.url`.
+
+- If the flow ran against the **production URL** already → no curl needed, assign **P0/P1** directly.
+- If the flow ran against a staging/preview/alias URL (different from production) → proceed to Step 3.
+- If production URL is `UNKNOWN` → skip curl, assign **P1 unverified** (Step 4, Case C).
+
+### Step 3: Curl the Failed Path on Production
+
+For each Critical finding, extract the path from the failed step and curl it on production:
+
+```bash
+# PATH_TO_CHECK: the route that failed, e.g. /es/tools/booster-pack
+PROD_CHECK=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 10 "${PROD_URL}${PATH_TO_CHECK}" 2>/dev/null)
+CHECK_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+```
+
+If `PATH_TO_CHECK` is just a domain (no path), use `/`.
+
+### Step 4: Assign Severity and File Issue
+
+**Case A — Production also fails** (`PROD_CHECK` is non-2xx or curl errors):
+- Severity: **P0** (for `error` status) or **P1** (for `fail` status)
+- Issue title: `[P0] {finding title}`
+- Production is broken for real users
+
+**Case B — Production returns 200, staging/preview fails**:
+- Severity: **P2**
+- Issue title: `[P2] {finding title} (staging only — prod healthy)`
+- This is a regression risk, not a live outage
+
+**Case C — Production URL unknown**:
+- Severity: **P1**
+- Issue title: `[P1] {finding title} (production status unverified)`
+- Body must include: "⚠️ Could not resolve production URL. Manual check required before treating this as P0."
+
+### Issue Body Template
+
+Every filed issue must include a **Production Check** evidence block:
+
+```markdown
+## Finding
+
+**Flow:** {flow-name}
+**Step {N}:** {action} → {target}
+**Observed:** {what happened}
+**Expected:** {what should have happened}
+**Snapshot:** {date}
+
+## Evidence
+
+**Walk URL:** {flow base URL}
+**Screenshot:** ![Step {N}]({evidence_url})
+**GIF:** ![Walk recording]({gif_url})
+
+## Production Check
+
+| Field | Value |
+|-------|-------|
+| URL checked | {prod_url}{path} |
+| HTTP status | {status_code or "curl failed"} |
+| Timestamp | {ISO timestamp} |
+| Result | {Production also failing / Production healthy (200) / Production URL unknown — manual check required} |
+
+## Suggested Fix
+
+{suggested_fix from report}
+
+**Effort:** {low|medium|high}
+
+---
+*Filed by FlowChad flow-report — walk snapshot: {snapshot_dir}*
+```
+
+### Severity Label Mapping
+
+| Case | GitHub label | Priority prefix |
+|------|-------------|-----------------|
+| Production fails | `P0` or `P1` | `[P0]` or `[P1]` |
+| Production 200, staging fails | `P2` | `[P2]` |
+| Production unknown | `P1` | `[P1]` |
+
+Use `gh label create` if the label doesn't exist yet:
+
+```bash
+gh label create "P0" --color "B60205" --description "Production broken" 2>/dev/null || true
+gh label create "P1" --color "D93F0B" --description "High severity" 2>/dev/null || true
+gh label create "P2" --color "E4E669" --description "Staging only, prod healthy" 2>/dev/null || true
+```
+
+File the issue:
+```bash
+gh issue create \
+  --repo "${REPO}" \
+  --title "{severity_prefix} {finding_title}" \
+  --body "{issue_body}" \
+  --label "{severity_label},flowchad"
+```
+
 ## After Report
 
 Print the report to the user and note the saved path. Suggest:

--- a/specs/32/plan.md
+++ b/specs/32/plan.md
@@ -1,0 +1,29 @@
+# Plan: Issue #32 — Production Impact Verification
+
+## Changes
+
+### 1. `flow-report/SKILL.md` — add "File Issues for Critical Findings" section
+
+Add after the existing "## After Report" section (or replace the implied issue-filing behavior with an explicit one).
+
+**What changes:**
+- New section "## File Issues for Critical Findings" with four sub-steps:
+  1. **Resolve production URL** — check `config.yml` `environments.production.url`; fall back to BRIEF.md, Vercel CLI (`gh api`), or mark as unknown
+  2. **Check if failure is on production already** — if the flow URL matches the production URL, skip the curl and assign P0/P1 directly
+  3. **Curl the failed path on production** — `curl -sI -o /dev/null -w "%{http_code}" --max-time 10 {prod_url}{path}` and record status + timestamp
+  4. **Assign severity and file issue** — three-case logic; include curl evidence block in issue body
+
+**Why flow-report:** This is the skill that interprets walk results and decides what to file. The walk itself is environment-agnostic; severity assignment belongs in the report phase.
+
+### 2. No other files change
+
+flow-walk, flow-suggest, config.yml, and other skills are unaffected. The production-check logic is self-contained in flow-report.
+
+## Order of Operations
+
+1. Write spec.md (done)
+2. Write plan.md (this file)
+3. Write tasks.md
+4. Edit `.flowchad/skills/flow-report/SKILL.md`
+5. Commit all to branch `32-production-impact-severity`
+6. Push and open PR

--- a/specs/32/spec.md
+++ b/specs/32/spec.md
@@ -1,0 +1,45 @@
+# Spec: Verify production impact before assigning severity (issue #32)
+
+## Problem Statement
+
+FlowChad's `flow-report` skill files GitHub issues for Critical findings without first checking whether the failure affects real production users. This led to:
+- fellowship-dev/farmesa#84: P0 "500 error" was on `farmesa.vercel.app` (stale alias), not `farmesa.cl` (production, healthy)
+- fellowship-dev/fellowship-dev-homepage-v2#25, #27: `/es` locale 404 on English-only site
+
+A test failure on a staging/preview domain is not a P0. Severity must reflect actual user impact.
+
+## Acceptance Criteria
+
+1. When `flow-report` is about to file a GitHub issue for a Critical finding, it first resolves the production URL.
+2. It curls the equivalent path on production and records the HTTP status + timestamp.
+3. Severity is assigned based on the curl result:
+   - Production also fails (non-2xx) → **P0/P1** (current behavior)
+   - Production returns 200 → **P2** (regression risk, not live impact)
+   - Production URL unknown → **P1** with "unverified" note, request manual check
+4. The filed issue body includes the production curl result as evidence (status code + timestamp + URL checked).
+5. Behavior only applies when the failed URL differs from the production URL (i.e., failure is on staging/preview).
+
+## Skill Files That Need Changes
+
+### `flow-report/SKILL.md` — primary change
+- The report currently classifies Critical findings and says "Print the report."
+- Issue filing is implied for Critical findings (AI interprets this and files).
+- **Add**: a new "## File Issues for Critical Findings" section that:
+  1. Resolves the production URL (from `config.yml` → `environments.production.url`, then `BRIEF.md`, then Vercel CLI, then falls back to unknown)
+  2. Curls the failed path on production
+  3. Decides severity using the three-case logic
+  4. Writes the issue body with curl evidence included
+
+## Open Questions (answered)
+
+**Q: Where is the production URL stored?**
+A: `config.yml` has an `environments.production.url` field (see schema). Falls back to: BRIEF.md `production:` field, `gh api` Vercel project settings, or unknown.
+
+**Q: What if the failed URL IS the production URL?**
+A: No curl needed — treat as P0/P1 directly.
+
+**Q: What if there are multiple Critical findings across different paths?**
+A: Curl each unique path on production. One curl per finding.
+
+**Q: Does flow-walk also file issues?**
+A: No. flow-walk stores results; flow-report generates the report and files issues. Only flow-report needs changing.

--- a/specs/32/tasks.md
+++ b/specs/32/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Issue #32
+
+## Task 1 — Add "File Issues for Critical Findings" section to flow-report
+
+**File:** `.flowchad/skills/flow-report/SKILL.md`
+**Where:** After the existing "## After Report" section
+**What:** New section with four steps:
+
+### Step 1: Resolve production URL
+- Read `config.yml` → look for `environments.production.url`
+- If not found, read `BRIEF.md` and grep for `production:` URL
+- If still not found, try `gh api /repos/{owner}/{repo} --jq .homepage`
+- If all fail, mark as `UNKNOWN`
+
+### Step 2: Determine if production check is needed
+- Extract the base URL from the failed step (from `results.json` → `config.url` or step navigate target)
+- If base URL matches `production_url`, no curl needed — assign P0/P1 directly
+- If base URL differs (staging/preview/alias), proceed to Step 3
+
+### Step 3: Curl each failed path on production
+For each Critical finding:
+```bash
+PATH_TO_CHECK=$(extract path from failed step URL)
+PROD_CHECK=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 10 "${PROD_URL}${PATH_TO_CHECK}")
+CHECK_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+```
+
+### Step 4: Assign severity and file issue
+Three-case logic:
+- `PROD_CHECK` is non-2xx (or UNKNOWN) → severity P0/P1, file as critical
+- `PROD_CHECK` is 2xx → severity P2, title prefix "[P2]", body notes prod is healthy
+- `PROD_URL` is UNKNOWN → severity P1, body includes "unverified" note
+
+Issue body must include evidence block:
+```markdown
+**Production check:**
+- URL checked: {prod_url}{path}
+- Status: {status_code}
+- Timestamp: {timestamp}
+- Result: {Production also failing / Production healthy (200) / Production URL unknown}
+```


### PR DESCRIPTION
Closes #32

## Summary

- `flow-report` now resolves the production URL before filing a GitHub issue for any Critical finding
- Curls the failed path on production (`curl -sI`) and records HTTP status + timestamp
- Severity logic: prod fails → P0/P1 (current); prod 200 → P2 (staging only); prod unknown → P1 unverified
- Every filed issue includes a **Production Check** table (URL checked, status, timestamp, result)

## What changed

**`.flowchad/skills/flow-report/SKILL.md`** — new "## File Issues for Critical Findings" section:
1. Resolves prod URL from `config.yml` → `BRIEF.md` → GitHub repo homepage
2. Skips curl if flow ran against prod directly (assigns P0/P1)
3. Curls each failed path; downgrades to P2 if prod is healthy
4. Files issue with curl evidence block in body; creates P0/P1/P2 labels as needed

**`specs/32/`** — spec, plan, and tasks files for this issue

## Test plan

- [ ] Walk a flow on a staging URL where a path fails → report files P2 if prod returns 200
- [ ] Walk a flow on a URL where prod also returns 5xx → report files P0/P1
- [ ] Walk a flow with no `environments.production.url` in config and no BRIEF.md → report files P1 with unverified note
- [ ] Filed issue body contains the Production Check table with correct status and timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)