### PR TITLE
feat: deploy-aware preflight — smoke config key + Navvi persona template

### DIFF
--- a/.flowchad/config.yml
+++ b/.flowchad/config.yml
@@ -56,13 +56,11 @@
 # [en, es] = generates /es/* paths for flows when walking locale-aware routes.
 # locales: [en]
 
-# Navvi persona (optional — enables authenticated flow walks)
-# Gopass entry: navvi/{persona}/email and navvi/{persona}/password
-# Used for flows that require login, form submissions, email verification.
-# persona: flowchad-myapp
+# Navvi persona for authenticated flows (optional)
+# Enables: real form submissions, email verification, sign-up flows
+# persona: flowchad-my-project  # gopass entry at navvi/flowchad-my-project/{email,password}
 
-# Smoketest config (optional — used by flowchad-runner in cron/CI mode)
-# NOTE: Schedule lives in crew.yml, NOT here.
-# smoketest:
-#   flows: [page-load, contact-form]        # flows to run in smoketest mode
-#   skip_production: [contact-form]         # flows to skip on production (unless persona available)
+# Smoke test configuration (schedule lives in crew.yml, not here)
+# smoke:
+#   flows: [page-load, contact-form]      # flows to run during smoke tests
+#   skip_production: [contact-form]       # skip these flows in production unless persona available

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -1,20 +1,20 @@
 # Quality Score — fellowship-dev/flowchad
 
-Last updated: 2026-04-21
+Last updated: 2026-04-24
 
 ## Domains
 
 | Domain | Grade | Last audit | Notes |
 |--------|-------|------------|-------|
-| flowchad-setup | A | 2026-04-21 | All signals green; code 3d ahead of docs |
-| flow-walk | A | 2026-04-21 | All signals green; code 3d ahead of docs |
-| flow-report | A | 2026-04-21 | All signals green; code 3d ahead of docs |
-| flow-add | A | 2026-04-21 | All signals green; code 3d ahead of docs |
-| flow-suggest | A | 2026-04-21 | All signals green; docs current (updated after last code change) |
-| flow-diff | A | 2026-04-21 | All signals green; docs current |
-| flow-diagram | A | 2026-04-21 | All signals green; docs current |
-| flow-update | A | 2026-04-21 | All signals green; docs current |
-| evidence-upload | A | 2026-04-21 | All signals green; docs current |
+| flowchad-setup | B | 2026-04-24 | S4 yellow: 4 open issues (>3 threshold); code 3d ahead of docs |
+| flow-walk | B | 2026-04-24 | S4 yellow: 5 open issues (>3 threshold); code 3d ahead of docs |
+| flow-report | B | 2026-04-24 | S4 yellow: 5 open issues (>3 threshold); code 3d ahead of docs |
+| flow-add | B | 2026-04-24 | S4 yellow: 6 open issues (>3 threshold); code 3d ahead of docs |
+| flow-suggest | A | 2026-04-24 | All signals green; 1 open issue; docs current |
+| flow-diff | A | 2026-04-24 | All signals green; 3 open issues (at threshold); docs current |
+| flow-diagram | A | 2026-04-24 | All signals green; 2 open issues; docs current |
+| flow-update | B | 2026-04-24 | S4 yellow: 5 open issues (>3 threshold); docs current |
+| evidence-upload | A | 2026-04-24 | All signals green; 0 open issues; docs current |
 
 ## Signal Applicability
 
@@ -30,8 +30,8 @@ Last updated: 2026-04-21
 
 ## Grade Summary
 
-- A: 9 (flowchad-setup, flow-walk, flow-report, flow-add, flow-suggest, flow-diff, flow-diagram, flow-update, evidence-upload)
-- B: 0
+- A: 4 (flow-suggest, flow-diff, flow-diagram, evidence-upload)
+- B: 5 (flowchad-setup, flow-walk, flow-report, flow-add, flow-update)
 - C: 0
 - D: 0
 - F: 0
@@ -41,3 +41,4 @@ Last updated: 2026-04-21
 | Date | Trigger | Summary |
 |------|---------|---------|
 | 2026-04-21 | tooling.dev daily sweep | 9 domains scanned, 0 regressions, 0 improvements — first sweep |
+| 2026-04-24 | tooling.cto entropy sweep | 9 domains scanned, 5 regressions (A→B), 0 improvements — open issue accumulation on core skills (flowchad-setup, flow-walk, flow-report, flow-add, flow-update) |


### PR DESCRIPTION
## Summary

- Updates `.flowchad/config.yml` template: renames `smoketest:` → `smoke:` to match the issue #30 spec
- Rewrites the Navvi persona comment block: clearer description with gopass path format and enabled use-cases
- Aligns the template with the flowchad-runner SKILL.md which reads `.smoke.flows[]` and `.smoke.skip_production[]`

Closes #30.

## Manual follow-up required

A gopass entry must be created manually with real farmesa credentials before authenticated flow walks can run:

```
gopass insert navvi/flowchad-farmesa/email
gopass insert navvi/flowchad-farmesa/password
```

This cannot be automated — real credentials must be entered interactively.

## Test plan

- [ ] Confirm `smoke:` key is present (not `smoketest:`) in the template comment
- [ ] Confirm persona comment shows gopass path format `navvi/flowchad-my-project/{email,password}`
- [ ] Confirm flowchad-runner SKILL.md reads `.smoke.flows[]` (see pylot PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)