### PR TITLE
docs: popsicle doc-quality sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# Flowchad — Developer Guide
+
+## What This Repo Is
+
+Flowchad is a **skills package**, not a traditional application. There is no source code to run, no build step, and no test suite. The repository contains:
+
+- **AI-readable skill specs** (`.flowchad/skills/*/SKILL.md`) — instructions for AI agents to execute each slash command
+- **Knowledge base** (`.flowchad/knowledge/`) — taxonomy, schema references, and domain docs
+- **Config template** (`.flowchad/config.yml`) — installed into user projects
+- **Flow templates** (`.flowchad/templates/`) — example flow definitions users copy and customize
+- **Shell utilities** (`scripts/`) — evidence init/upload helpers called by skill specs
+- **User-facing docs** (`README.md`, `docs/`) — installation, quick start, reference
+
+Skills are distributed via `npx skills add Fellowship-dev/flowchad --skill '*'` and installed into the user's agent directory (`.agents/skills/`, `.claude/skills/`, etc.).
+
+## Repository Structure
+
+```
+flowchad/
+├── .flowchad/
+│   ├── config.yml             # Config template (copied to user projects on install)
+│   ├── flows/                 # (empty in this repo; populated in user projects)
+│   ├── templates/             # Example flows: sign-up.yml, login.yml, checkout.yml, onboarding.yml
+│   ├── knowledge/             # Domain docs: friction taxonomy, flow schema, metrics, platform types
+│   │   ├── flow-anatomy.md    # How to decompose products into testable flows
+│   │   ├── flow-schema.md     # Full YAML schema reference for flow definitions
+│   │   ├── friction-taxonomy.md  # Critical/Friction/Cosmetic classification decision tree
+│   │   ├── goal-setting.md    # Business→Product→Flow goal hierarchy
+│   │   ├── metrics-primer.md  # Latency, error rate, visual consistency guidance
+│   │   └── platform-types.md  # Evaluation criteria per platform type
+│   ├── commands/              # Command signatures (stub files, not implementations)
+│   └── skills/                # Skill implementations (AI-readable SKILL.md specs)
+│       ├── flowchad-setup/    # Initialize project, auto-discover flows
+│       ├── flow-walk/         # Execute flow steps, capture screenshots + video
+│       ├── flow-report/       # Analyze results, generate friction report, file issues
+│       ├── flow-add/          # Create new flow from natural language
+│       ├── flow-update/       # Update flow after product changes
+│       ├── flow-suggest/      # Prioritize improvements by effort vs impact
+│       ├── flow-diff/         # Compare snapshots, detect regressions
+│       ├── flow-diagram/      # Generate Mermaid flowcharts from flow definitions
+│       └── evidence-upload/   # Upload screenshots/GIFs to git/S3/Navvi
+├── scripts/
+│   ├── detect-i18n.sh         # Auto-detect supported locales from project config
+│   ├── evidence-init.sh       # Create git orphan branch for evidence storage
+│   └── evidence-upload.sh     # Upload file to git/S3 evidence backend
+├── docs/                      # Extended reference documentation
+├── specs/                     # Accepted feature specs (e.g., production impact verification)
+├── install.sh                 # Installs .flowchad/ into a user's project
+├── README.md                  # Public-facing docs (quick start, reference)
+└── QUALITY_SCORE.md           # Per-skill quality grades and open issue tracking
+```
+
+## The Nine Skills
+
+Each skill is an AI-readable SKILL.md spec that an agent executes when the user invokes the slash command:
+
+| Command | What it does |
+|---------|-------------|
+| `/flowchad-setup` | Auto-discovers routes, tests, analytics — scaffolds `.flowchad/config.yml` and flow definitions |
+| `/flow-walk <name>` | Executes flow steps via Playwright CDP, captures screenshots + timing + video |
+| `/flow-report <name>` | Classifies findings as Critical/Friction/Cosmetic, generates markdown report, files GitHub issues |
+| `/flow-add <description>` | Creates a new flow YAML from natural language, scanning codebase for selectors |
+| `/flow-update <name> <change>` | Updates an existing flow to reflect product changes |
+| `/flow-suggest <name>` | Produces prioritized improvement plan ranked by effort vs impact |
+| `/flow-diff <name>` | Compares walk snapshots across time to detect regressions |
+| `/flow-diagram <name>` | Generates Mermaid flowchart from a flow definition |
+| `/evidence-upload` | Uploads screenshots/GIFs to configured evidence backend (called internally by other skills) |
+
+## Key Concepts
+
+### Skill Specs vs Knowledge Docs
+
+**Skill specs** (`.flowchad/skills/*/SKILL.md`) are executable instructions for the AI — they tell the agent *how* to perform each command. They include shell commands, JavaScript snippets, and step-by-step procedures.
+
+**Knowledge docs** (`.flowchad/knowledge/`) are reference material the AI reads *during* skill execution — the friction taxonomy, flow schema, and platform criteria are loaded by skills as needed.
+
+### Config Template vs User Config
+
+The `.flowchad/config.yml` in this repo is a **template** — it ships to the user's project on install. In a user's project, they fill in their actual URL, type, credentials, etc. Never commit credentials into this template; all sensitive values use `$ENV_VAR` references.
+
+### Evidence Branches
+
+The git evidence backend uses an orphan branch (default: `evidence`) — a branch with no shared history, used purely for storing binary artifacts (screenshots, GIFs). This keeps evidence out of the main git history while making URLs publicly accessible via GitHub's raw content endpoint.
+
+## Working on Skill Specs
+
+Skill specs are the core product. When editing a SKILL.md:
+
+1. **Algorithm changes** — update both the SKILL.md narrative and any code snippets together. The AI reads both and will be confused if they contradict.
+2. **New output fields** — if you add fields to `results.json`, update the schema in `flow-walk/SKILL.md` and any downstream skill that reads results (flow-report, flow-diff, flow-suggest).
+3. **Config additions** — add new fields to `.flowchad/config.yml` as commented-out examples with inline documentation.
+4. **Knowledge changes** — if the friction taxonomy or flow schema changes, update the relevant knowledge file *and* check that the affected skill specs reference the correct file path.
+
+## Working on Shell Scripts
+
+The scripts in `scripts/` are called by skill specs. They are plain bash, keep them portable (no bash 4+ features, no `greadlink`, etc.). Test on both macOS and Linux.
+
+## Contributing
+
+- Open an issue before a large refactor — skill specs have subtle dependencies
+- QUALITY_SCORE.md tracks per-skill health; update it when closing skill-related issues
+- The `specs/` directory contains accepted feature specs; reference them in PRs
+
+## Requirements (for users installing this package)
+
+- An AI coding agent (Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini, OpenHands, or [40+ others](https://skills.sh))
+- Chrome or Chromium (Playwright CDP, or headless)
+- `ffmpeg` (optional — needed for video recording and smart-trimming)
+- [Navvi](https://github.com/Fellowship-dev/navvi) (optional — needed for flows with CAPTCHAs or bot detection)

--- a/README.md
+++ b/README.md
@@ -140,12 +140,18 @@ Or skip manual YAML and let AI create it:
 
 ## Video Recording
 
-Flow walks automatically record video. The recording is **smart-trimmed** — dead frames where nothing happens are cut out, keeping only 1s before and 3s after each action.
+Flow walks automatically record video. The recording is **smart-trimmed** — dead frames where nothing happens are cut out.
+
+**Trim algorithm:**
+1. Build an action log — a timestamp is recorded before each step executes.
+2. For each logged action, compute a keep-window: 1 second before the action, 3 seconds after (for `fill` steps: typing duration + 3 seconds after).
+3. Merge overlapping keep-windows.
+4. If the merged windows cover less than 80% of the original duration (i.e., trimming saves >20%), produce the trimmed cut via ffmpeg. Otherwise keep the full recording only.
 
 Output:
-- `{flow-name}.mp4` — full recording
-- `{flow-name}-trimmed.mp4` — action-only cut (if trim saves >20%)
-- `{flow-name}.gif` — palette-optimized GIF for issues/PRs
+- `{flow-name}-full.webm` — raw Playwright recording
+- `{flow-name}-trimmed.mp4` — action-only cut (created only if trim saves >20%)
+- `{flow-name}.gif` — palette-optimized GIF for issues/PRs (from trimmed cut if available, else full)
 
 Disable with `video: false` in your flow YAML or config.
 
@@ -248,6 +254,36 @@ Reports classify every finding into three levels:
 - **Cosmetic** — works fine but looks rough (typos, alignment, placeholder text)
 
 Each finding includes what's wrong, why it matters, a suggested fix, and effort estimate.
+
+### Issue Priority (P0 / P1 / P2)
+
+When `/flow-report` files GitHub issues for Critical findings, it first checks whether production is actually affected:
+
+1. Resolves the production URL from (in order): `config.yml → environments.production.url`, then `BRIEF.md` in the project root, then `gh api` repo homepage field.
+2. Curls the failed path on production.
+3. Assigns priority based on the result:
+
+| Result | Priority | Label |
+|--------|----------|-------|
+| Production also fails (non-2xx) | **P0** (error) or **P1** (fail) | `[P0]` or `[P1]` |
+| Production returns 200, staging fails | **P2** — regression risk only | `[P2] … (staging only — prod healthy)` |
+| Production URL could not be resolved | **P1 unverified** | `[P1] … (production status unverified)` |
+
+If the flow was already run against the production URL, no curl is needed — P0/P1 is assigned directly.
+
+## Locale Detection
+
+`/flowchad-setup` auto-detects which locales your project supports. The detection runs in this priority order:
+
+1. **Next.js config** — reads `i18n.locales` from `next.config.js` / `next.config.ts`
+2. **Locale directories** — looks for `locales/` or `messages/` directories in the project root
+3. **Strapi i18n plugin** — checks for Strapi i18n configuration
+4. **hreflang tags** — fetches the production homepage and reads `<link rel="alternate" hreflang="...">` tags
+5. **Default** — falls back to `[en]` (English only, no locale-prefixed paths)
+
+The detected locales are written to `locales:` in `.flowchad/config.yml`. Re-run `/flowchad-setup` after i18n config changes.
+
+When walking flows, `locales: [en]` means routes are walked as-is (no `/en/` prefix). `locales: [en, es]` walks each route twice — once at the base path and once at the `/es/`-prefixed path — and reports results per locale.
 
 ## Project Structure
 

--- a/docs/popsicle-report-2026-05-01.md
+++ b/docs/popsicle-report-2026-05-01.md
@@ -1,0 +1,32 @@
+# Popsicle Report — flowchad
+**Date**: 2026-05-01
+**Iteration**: 1
+**Concepts tested**: 10
+**Pass rate**: 9/10 (90%)
+
+## Results
+
+| # | Concept | Category | S1 | S2 | Verdict |
+|---|---------|----------|----|----|---------|
+| 1 | Project Purpose & Package Type | architecture | PASS | PASS | PASS |
+| 2 | Installation Steps & Requirements | install | PASS | PASS | PASS |
+| 3 | Skills Overview (9 commands) | skills | PASS | PASS | PASS |
+| 4 | Config Schema (config.yml) | config | PASS | PASS | PASS |
+| 5 | Flow Definition YAML Schema | flow-schema | PASS | PASS | PASS |
+| 6 | Friction Taxonomy (Critical/Friction/Cosmetic) | friction | PASS | PASS | PASS |
+| 7 | Evidence Backends (git/S3/Navvi) | evidence | PASS | PASS | PASS |
+| 8 | Smart-Trimming Algorithm | video | PASS | PASS | PASS |
+| 9 | Production Impact Verification (P0/P1/P2) | reporting | PASS | PASS | PASS |
+| 10 | Locale Auto-Detection Order | i18n | FAIL | FAIL | FAIL |
+
+## Gaps Remaining
+
+- **Locale Auto-Detection (hreflang step)**: Both validation sessions cited README steps 1, 2, 3, and 5 but reported step 4 (hreflang tag detection) as absent from the docs. The hreflang step *is* present in the README at line 281, but both independent sessions failed to surface it — possibly due to the `<link rel="alternate" hreflang="...">` code span being mistaken for a missing/empty list item in the session's rendering context. Consider rewording step 4 to avoid the inline HTML angle brackets.
+
+## Doc Changes This Iteration
+
+- **Added `CLAUDE.md`**: Full developer guide covering the skills-package architecture, repo directory structure, nine-skills table, key concepts (skill specs vs knowledge docs, config template, evidence orphan branch), working notes for skill spec and shell script contributors, and system requirements.
+- **Updated `README.md` — Video Recording section**: Expanded smart-trimming section with the complete algorithm: action log construction, keep-window calculation (1s before / 3s after each action; typing duration + 3s for `fill` steps), overlapping-window merging, and >20% threshold condition. Corrected output file names to match SKILL.md (`-full.webm`, `-trimmed.mp4`, `.gif`).
+- **Updated `README.md` — Friction Reports section**: Added "Issue Priority (P0 / P1 / P2)" subsection documenting the production impact verification flow: URL resolution order (config.yml → BRIEF.md → gh api), the curl check, and the three-case priority table (P0/P1 if prod fails, P2 if staging-only, P1-unverified if prod URL unknown).
+- **Updated `README.md` — new Locale Detection section**: Added section documenting the 5-step auto-detection priority order (Next.js config → locale dirs → Strapi → hreflang tags → default `[en]`) and how locales drive flow walking behaviour.
+- **Created `docs/` directory**: Scaffolded for future extended reference docs.


### PR DESCRIPTION
## Popsicle Doc-Quality Sweep

Automated documentation pass using the popsicle sensor. Discovers undocumented concepts via code scan, writes docs, then validates with fresh agent sessions that can only read docs.

**Pass rate: 9/10 (90%) — above 80% threshold. Loop stopped after 1 iteration.**

---

## What Changed

- **Added `CLAUDE.md`**: Full developer guide — skills-package architecture, repo structure, nine-skills table, key concepts (skill specs vs knowledge docs, config template, evidence orphan branch), contributor notes, system requirements.
- **Updated `README.md` — Video Recording**: Expanded smart-trimming algorithm (action log, keep-window calc, overlap merging, >20% threshold), corrected output file names.
- **Updated `README.md` — Friction Reports**: Added "Issue Priority (P0/P1/P2)" subsection with production impact verification flow.
- **Updated `README.md` — Locale Detection**: New section on 5-step auto-detection order (Next.js config → locale dirs → Strapi → hreflang → default `[en]`).
- **Created `docs/` directory**: Scaffolded for future extended reference.

---

## Popsicle Report Summary

| # | Concept | Category | Verdict |
|---|---------|----------|---------|
| 1 | Project Purpose & Package Type | architecture | PASS |
| 2 | Installation Steps & Requirements | install | PASS |
| 3 | Skills Overview (9 commands) | skills | PASS |
| 4 | Config Schema (config.yml) | config | PASS |
| 5 | Flow Definition YAML Schema | flow-schema | PASS |
| 6 | Friction Taxonomy (Critical/Friction/Cosmetic) | friction | PASS |
| 7 | Evidence Backends (git/S3/Navvi) | evidence | PASS |
| 8 | Smart-Trimming Algorithm | video | PASS |
| 9 | Production Impact Verification (P0/P1/P2) | reporting | PASS |
| 10 | Locale Auto-Detection Order | i18n | FAIL |

**Gap remaining**: Locale detection hreflang step (step 4) is present in README but both validation sessions failed to surface it — inline HTML angle brackets in a list item may cause rendering confusion. Consider rewording to avoid `<link rel="alternate" hreflang="...">` inline HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)