### PR TITLE
docs: popsicle v2 — 100% doc pass rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ credentials:
   password: $TEST_PASSWORD
 ```
 
+The `type` field tells the AI which evaluation criteria to apply during `/flow-report`:
+
+| Type | Product category | Focus areas |
+|------|-----------------|-------------|
+| `saas` | Web app with accounts | Onboarding, conversion funnels, billing, collaboration |
+| `website` | Marketing / docs / blog | SEO, accessibility, Core Web Vitals, CTAs |
+| `mobile` | iOS / Android app | Touch targets, offline behavior, gestures, state preservation |
+| `internal` | Admin / ops tool | Efficiency (clicks-to-task), power-user patterns, error recovery |
+
 **3. Define a flow** — create `.flowchad/flows/new-user-signs-up-with-email-and-password.yml`:
 
 ```yaml
@@ -169,7 +178,11 @@ evidence:
 
 ```bash
 ./scripts/evidence-init.sh owner/repo
+# or omit the repo — it auto-detects from your git remote origin:
+./scripts/evidence-init.sh
 ```
+
+The script is idempotent: if the evidence branch already exists it exits cleanly with no changes.
 
 **S3/R2 backend** — for teams with existing cloud storage. Set `s3_bucket`, `s3_endpoint`, and `s3_public_url` in config.
 
@@ -210,7 +223,7 @@ context:
 | `fill` | `selector`, `value` | Type into an input |
 | `click` | `selector` | Click an element |
 | `select` | `selector`, `value` | Choose from dropdown |
-| `scroll` | `selector` or `direction` | Scroll to element or direction |
+| `scroll` | `selector` or `value` | Scroll to element or to a direction (`top`/`bottom`/`down`) |
 | `wait` | `selector` or `ms` | Wait for element or duration |
 | `hover` | `selector` | Hover over element |
 
@@ -226,6 +239,16 @@ context:
   optional: true                     # don't fail the flow if this breaks
   captcha: true                      # skip in headless, delegate to Navvi
 ```
+
+**Timing thresholds** — steps that exceed `timing` are reported as Friction findings. General guidance:
+
+| Duration | Perception | Guidance |
+|----------|------------|----------|
+| < 300ms | Fast | Acceptable for most interactions |
+| 300ms – 1s | Noticeable | Needs a loading indicator or skeleton screen |
+| 1s – 3s | Slow | Requires a progress indicator; users may lose context |
+| > 3s | Frustrating | Must show progress with time estimate |
+| > 10s | Broken | Users assume failure; provide cancel and recovery |
 
 ### Flow-Level Options
 
@@ -277,8 +300,8 @@ If the flow was already run against the production URL, no curl is needed — P0
 
 1. **Next.js config** — reads `i18n.locales` from `next.config.js` / `next.config.ts`
 2. **Locale directories** — looks for `locales/` or `messages/` directories in the project root
-3. **Strapi i18n plugin** — checks for Strapi i18n configuration
-4. **hreflang tags** — fetches the production homepage and reads `<link rel="alternate" hreflang="...">` tags
+3. **Strapi i18n plugin** — checks for Strapi i18n configuration (locales are stored in DB; detection falls through to step 4)
+4. **hreflang tags** — fetches the production homepage URL (from `config.yml`) and parses `link[rel=alternate][hreflang]` tags to extract locale codes
 5. **Default** — falls back to `[en]` (English only, no locale-prefixed paths)
 
 The detected locales are written to `locales:` in `.flowchad/config.yml`. Re-run `/flowchad-setup` after i18n config changes.

--- a/docs/popsicle-report-2026-05-01-v2.md
+++ b/docs/popsicle-report-2026-05-01-v2.md
@@ -1,0 +1,38 @@
+# Popsicle Report — flowchad
+
+**Date**: 2026-05-01
+**Iteration**: 2
+**Concepts tested**: 8
+**Pass rate**: 8/8 (100%)
+
+## Results
+
+| # | Concept | Category | S1 | S2 | Verdict |
+|---|---------|----------|----|----|---------|
+| 1 | Locale Auto-Detection Order | i18n | PASS | PASS | PASS |
+| 2 | Scroll Action Field Name (`value` vs `direction`) | flow-schema | PASS | PASS | PASS |
+| 3 | evidence-init.sh Auto-Detect + Idempotency | evidence | PASS | PASS | PASS |
+| 4 | config.yml `type` Field Values + Meaning | config | PASS | PASS | PASS |
+| 5 | Latency Timing Thresholds | metrics | PASS | PASS | PASS |
+| 6 | npx skills update Bug + Workaround | install | PASS | PASS | PASS |
+| 7 | `optional: true` Step Behavior | flow-schema | PASS | PASS | PASS |
+| 8 | `captcha: true` + Navvi Delegation | captcha | PASS | PASS | PASS |
+
+## Gaps Remaining
+
+None. All 8 concepts PASSed with both sessions answering correctly.
+
+## Doc Changes This Iteration
+
+- **Fixed `README.md` — Locale Detection step 4**: Rewrote the hreflang detection step to avoid inline HTML angle brackets (`<link ...>` syntax that caused rendering issues in prior sessions). Now reads "parses `link[rel=alternate][hreflang]` tags" — plain CSS selector syntax that renders cleanly in any context.
+- **Fixed `README.md` — Action table**: Corrected `scroll` action field name from `direction` (incorrect) to `value` with the valid direction values (`top`/`bottom`/`down`).
+- **Updated `README.md` — Evidence Upload section**: Added note that `evidence-init.sh` auto-detects the repo from `git remote origin` when no argument is given, and that the script is idempotent (exits cleanly if the branch already exists).
+- **Updated `README.md` — Quick Start section**: Added `type` field explanation table mapping `saas`/`website`/`mobile`/`internal` to product category and evaluation focus areas.
+- **Updated `README.md` — Step Options section**: Added latency threshold guidance table after the `timing:` step option docs, covering the full range from <300ms (fast) to >10s (broken/users assume failure).
+
+## Cumulative Quality (Iterations 1–2)
+
+| Iteration | Concepts | Pass Rate | Key Fixes |
+|-----------|----------|-----------|-----------|
+| 1 | 10 | 9/10 (90%) | Initial CLAUDE.md, video trim algo, P0/P1/P2 priority, locale section |
+| 2 | 8 | 8/8 (100%) | Hreflang fix, scroll field fix, type table, latency thresholds, evidence-init note |


### PR DESCRIPTION
## Summary

Second popsicle run on fellowship-dev/flowchad, targeting the one FAIL from iteration 1 (Locale Auto-Detection Order hreflang step) plus 7 new concepts. **All 8 concepts passed 100% with independent validation sessions.**

## Popsicle Report — Iteration 2

**Date**: 2026-05-01 | **Pass rate**: 8/8 (100%)

| # | Concept | S1 | S2 | Verdict |
|---|---------|----|----|---------|
| 1 | Locale Auto-Detection Order | PASS | PASS | PASS |
| 2 | Scroll Action Field Name (`value` vs `direction`) | PASS | PASS | PASS |
| 3 | evidence-init.sh Auto-Detect + Idempotency | PASS | PASS | PASS |
| 4 | config.yml `type` Field Values + Meaning | PASS | PASS | PASS |
| 5 | Latency Timing Thresholds | PASS | PASS | PASS |
| 6 | npx skills update Bug + Workaround | PASS | PASS | PASS |
| 7 | `optional: true` Step Behavior | PASS | PASS | PASS |
| 8 | `captcha: true` + Navvi Delegation | PASS | PASS | PASS |

## Doc Changes

- **Fixed hreflang step**: Rewrote Locale Detection step 4 to avoid inline HTML angle brackets that confused validator sessions — now uses plain CSS selector syntax `link[rel=alternate][hreflang]`
- **Fixed scroll action**: Corrected field name from `direction` → `value` in the Action table
- **Added type field table**: Maps `saas`/`website`/`mobile`/`internal` to evaluation focus areas
- **Added latency thresholds**: Full range guide (<300ms fast → >10s broken) after `timing:` docs
- **Added evidence-init.sh note**: Auto-detects repo from git remote; idempotent (safe to re-run)

## Cumulative Quality

| Iteration | Concepts | Pass Rate |
|-----------|----------|-----------|
| 1 (merged in #36) | 10 | 90% |
| 2 (this PR) | 8 | 100% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)