### PR TITLE
feat: add /flow-reproduce skill for customer bug reproduction (#28)

### DIFF
--- a/.flowchad/commands/flow-reproduce.md
+++ b/.flowchad/commands/flow-reproduce.md
@@ -1,0 +1,18 @@
+---
+description: Reproduce a customer-reported bug in-browser — reads a GitHub issue, infers a reproduction flow, walks it via Playwright, and updates the issue with evidence and a reproduced/could-not-reproduce label
+disable-model-invocation: false
+---
+
+Reproduce the bug described in GitHub issue $ARGUMENTS using the flow-reproduce skill.
+
+1. Parse $ARGUMENTS as a GitHub issue reference (bare number, `owner/repo#N`, or full URL)
+2. Fetch the issue body and comments from GitHub
+3. Extract error context: error message, affected URL, triggering action, auth state
+4. Infer a minimal reproduction flow and save it to `.flowchad/flows/reproduce-issue-{N}.yml`
+5. Walk the flow using Playwright CDP, capturing screenshots and video
+6. Determine outcome: `reproduced` or `could-not-reproduce`
+7. Upload evidence and post a structured comment to the original issue
+8. Apply `reproduced` or `could-not-reproduce` label to the issue
+9. Print the outcome summary and display the GIF
+
+Follow the flow-reproduce skill instructions exactly.

--- a/.flowchad/skills/flow-reproduce/SKILL.md
+++ b/.flowchad/skills/flow-reproduce/SKILL.md
@@ -369,20 +369,20 @@ Save outcome to `results.json`:
 REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|')
 
 # Initialize evidence branch if needed
-bash scripts/evidence-init.sh "$REPO" 2>/dev/null || true
+.flowchad/../scripts/evidence-init.sh "$REPO" 2>/dev/null || true
 
 # Upload screenshots
 GIF_URL=""
 for screenshot in "${SNAPSHOT_DIR}"/step-*.png; do
   [ -f "$screenshot" ] || continue
   FNAME=$(basename "$screenshot")
-  bash scripts/evidence-upload.sh "$screenshot" "$REPO" \
+  .flowchad/../scripts/evidence-upload.sh "$screenshot" "$REPO" \
     "reproduce-issue-${ISSUE_NUMBER}/${DATE}/${FNAME}" 2>/dev/null || true
 done
 
 # Upload GIF
 if [ -f "${SNAPSHOT_DIR}/reproduce-issue-${ISSUE_NUMBER}.gif" ]; then
-  GIF_URL=$(bash scripts/evidence-upload.sh \
+  GIF_URL=$(.flowchad/../scripts/evidence-upload.sh \
     "${SNAPSHOT_DIR}/reproduce-issue-${ISSUE_NUMBER}.gif" \
     "$REPO" \
     "reproduce-issue-${ISSUE_NUMBER}/${DATE}/reproduce-issue-${ISSUE_NUMBER}.gif" 2>/dev/null) || true

--- a/.flowchad/skills/flow-reproduce/SKILL.md
+++ b/.flowchad/skills/flow-reproduce/SKILL.md
@@ -1,0 +1,551 @@
+---
+name: flow-reproduce
+description: Reproduce a customer-reported bug in-browser given a GitHub issue with error details. Walks an inferred flow, captures evidence, and updates the original issue with reproduction outcome + steps-to-reproduce. Usage /flow-reproduce <issue-ref>
+user_invocable: true
+---
+
+# Flow Reproduce
+
+Given a GitHub issue containing error details (stack trace, user action, URL), attempt to reproduce the bug in-browser. Attach a screen recording and structured steps-to-reproduce to the original issue, then label it `reproduced` or `could-not-reproduce`.
+
+## Usage
+
+```
+/flow-reproduce 42
+/flow-reproduce fellowship-dev/myapp#42
+/flow-reproduce https://github.com/fellowship-dev/myapp/issues/42
+```
+
+The argument is a GitHub issue reference. If the project has a default repo configured in `.flowchad/config.yml` (via `repo:` field), a bare number works. Otherwise use the full `owner/repo#N` form or a GitHub issue URL.
+
+---
+
+## Phase 1: Parse Issue Context
+
+### Step 1a: Resolve the Issue Reference
+
+Parse the argument to extract `OWNER`, `REPO`, and `ISSUE_NUMBER`:
+
+```bash
+ARG="$1"
+
+# Full URL: https://github.com/owner/repo/issues/42
+if echo "$ARG" | grep -qE '^https://github\.com/'; then
+  OWNER=$(echo "$ARG" | sed -E 's|https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)|\1|')
+  REPO=$(echo "$ARG" | sed -E 's|https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)|\2|')
+  ISSUE_NUMBER=$(echo "$ARG" | sed -E 's|https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)|\3|')
+  FULL_REPO="${OWNER}/${REPO}"
+
+# owner/repo#N form
+elif echo "$ARG" | grep -qE '^[^/]+/[^#]+#[0-9]+$'; then
+  FULL_REPO=$(echo "$ARG" | cut -d'#' -f1)
+  ISSUE_NUMBER=$(echo "$ARG" | cut -d'#' -f2)
+
+# Bare number — use git remote or config.yml repo field
+else
+  ISSUE_NUMBER="$ARG"
+  FULL_REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|' \
+    || grep '^repo:' .flowchad/config.yml 2>/dev/null | awk '{print $2}')
+fi
+
+if [ -z "$FULL_REPO" ] || [ -z "$ISSUE_NUMBER" ]; then
+  echo "Error: could not resolve repo. Pass the full reference: owner/repo#N or a GitHub issue URL."
+  exit 1
+fi
+
+echo "Fetching issue #${ISSUE_NUMBER} from ${FULL_REPO}..."
+```
+
+### Step 1b: Fetch Issue Data
+
+```bash
+ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" \
+  --repo "$FULL_REPO" \
+  --json title,body,labels,comments,url,state)
+
+ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body')
+ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r '.url')
+ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
+
+# Combine body + all comments for full context
+ISSUE_COMMENTS=$(echo "$ISSUE_JSON" | jq -r '.comments[].body' 2>/dev/null | tr '\n' ' ')
+FULL_CONTEXT="${ISSUE_BODY} ${ISSUE_COMMENTS}"
+
+echo "Issue: ${ISSUE_TITLE}"
+echo "State: ${ISSUE_STATE}"
+```
+
+If the issue is already CLOSED, skip to Phase 5 (post comment noting it's closed, apply `could-not-reproduce` label if not already labeled) then exit.
+
+### Step 1c: Extract Error Context (AI-Assisted Parsing)
+
+Read the full issue context and extract:
+
+**Error message** — look for patterns like:
+- `Error: <message>`
+- `Exception: <message>`
+- `TypeError: <message>`
+- `Uncaught <ErrorClass>: <message>`
+- Bugsnag `error_class` / `error_message` fields
+- Sentry `"type"` / `"value"` fields in JSON payloads
+- Any line starting with a capitalized word followed by `: ` (heuristic)
+
+**Affected URL** — look for:
+- Explicit URLs starting with `http://` or `https://`
+- Route patterns like `/path/to/page`, `/users/123/settings`
+- Browser location context in Bugsnag/Sentry payloads
+
+**Triggering action** — look for:
+- Action keywords: "clicked", "click", "submitted", "submit", "navigated", "navigating", "scrolled", "loaded", "opened", "pressed"
+- Button/link names following the action keyword
+- Form names or field names
+
+**Auth state** — infer from:
+- Keywords: "logged in", "authenticated", "signed in", "my account", "dashboard", "admin" → `logged_in`
+- Keywords: "logged out", "not logged in", "anonymous", "homepage", "landing" → `logged_out`
+- Default to `logged_in` if ambiguous (most bugs happen in authenticated sessions)
+
+**Stack trace hints** — extract the top 3 frames if a stack trace is present. Do not attempt to execute stack trace code — use it only as context for the `expect` assertions.
+
+Store extracted fields:
+```
+ERROR_MESSAGE=<extracted or "unknown error">
+AFFECTED_URL=<extracted or "">
+TRIGGERING_ACTION=<extracted or "">
+AUTH_STATE=<logged_in|logged_out>
+STACK_HINT=<top frame or "">
+```
+
+If `AFFECTED_URL` is empty after parsing, **ask the user before proceeding**:
+```
+Could not infer the affected URL from issue #${ISSUE_NUMBER}.
+Please provide the URL where the bug occurs (e.g., https://staging.example.com/settings):
+```
+Wait for the user's response and use it as `AFFECTED_URL`.
+
+---
+
+## Phase 2: Infer Reproduction Flow
+
+### Step 2a: Build Flow YAML
+
+Construct a minimal reproduction flow. The goal is the fewest steps needed to reach and trigger the bug.
+
+**Standard flow structure:**
+
+```yaml
+# .flowchad/flows/reproduce-issue-{N}.yml
+name: Reproduce issue #{N} — {ERROR_MESSAGE} at {AFFECTED_URL}
+url: {BASE_URL_FROM_CONFIG_OR_AFFECTED_URL}
+tags: [reproduction, issue-{N}]
+priority: P0
+locales: [en]
+context:
+  user: {AUTH_STATE}
+  auth: {AUTH_STATE}
+  source_issue: "{ISSUE_URL}"
+  error: "{ERROR_MESSAGE}"
+
+steps:
+  - action: navigate
+    url: {AFFECTED_URL_PATH}
+    expect: >
+      Page loads without a full-page error. The relevant UI for {TRIGGERING_ACTION or "the reported action"}
+      should be visible. If a 500, 404, or error page appears, that is the bug.
+    timing: 5s
+
+  # Add triggering action step if one was identified
+  # {TRIGGERING_ACTION_STEP — see rules below}
+
+  - action: wait
+    selector: "body"
+    expect: >
+      Observe the page state after {TRIGGERING_ACTION or "navigation"}.
+      Look for: JavaScript console errors, error banners, empty states where content
+      should be, broken UI elements, redirect loops, or any indicator matching
+      the reported error "{ERROR_MESSAGE}".
+    timing: 3s
+```
+
+**Triggering action step rules:**
+
+- If action is `click` + button/link identified → `action: click, selector: [text or data-testid]`
+- If action is `submit` or `fill` → `action: fill` for each field, then `action: click` on submit
+- If action is `navigate` or `load` → no extra step (already covered by first `navigate`)
+- If action is `scroll` → `action: scroll, selector: body`
+- If action is ambiguous → add a `wait` with a rich `expect` that describes what to look for
+
+**Auth preamble:** If `AUTH_STATE=logged_in` and config.yml has credentials, prepend login steps:
+
+```yaml
+  - action: navigate
+    url: /login
+    expect: Login form is visible with email and password fields.
+    timing: 3s
+
+  - action: fill
+    selector: "[name=email], [type=email], #email"
+    value: $TEST_USER_EMAIL
+    expect: Email field accepts input.
+
+  - action: fill
+    selector: "[name=password], [type=password], #password"
+    value: $TEST_USER_PASSWORD
+    expect: Password field accepts input.
+
+  - action: click
+    selector: "[type=submit], button[type=submit], .login-button"
+    expect: Login succeeds and user is redirected to the app. Auth cookies set.
+    timing: 5s
+```
+
+If credentials are not configured, add a comment in the YAML noting manual auth may be required, and proceed anyway (the navigate step will hit the login redirect which may itself be informative).
+
+### Step 2b: Resolve Base URL
+
+```bash
+# Priority: environments.staging.url > url > environments.production.url
+BASE_URL=$(grep -A2 'staging:' .flowchad/config.yml 2>/dev/null | grep 'url:' | awk '{print $2}' | head -1)
+BASE_URL="${BASE_URL:-$(grep '^url:' .flowchad/config.yml 2>/dev/null | awk '{print $2}' | head -1)}"
+BASE_URL="${BASE_URL:-$(echo "$AFFECTED_URL" | sed -E 's|(https?://[^/]+).*|\1|')}"
+
+# Strip trailing slash
+BASE_URL="${BASE_URL%/}"
+```
+
+If `AFFECTED_URL` is a full URL, compute `AFFECTED_URL_PATH` as the path component:
+```bash
+AFFECTED_URL_PATH=$(echo "$AFFECTED_URL" | sed -E 's|https?://[^/]+(/.*)?|\1|')
+AFFECTED_URL_PATH="${AFFECTED_URL_PATH:-/}"
+```
+
+### Step 2c: Save Flow and Confirm
+
+Save the inferred flow to `.flowchad/flows/reproduce-issue-${ISSUE_NUMBER}.yml`.
+
+Print the inferred flow to the user:
+```
+## Inferred Reproduction Flow
+
+File: .flowchad/flows/reproduce-issue-{N}.yml
+Steps: {step_count}
+
+{YAML content}
+
+Proceeding with walk...
+```
+
+Auto-proceed (do not require confirmation). The user can interrupt if the flow looks wrong.
+
+---
+
+## Phase 3: Walk the Flow
+
+Execute the inferred flow using the same Playwright CDP model as `flow-walk`. Refer to that skill for the full execution specification. Key points for reproduction:
+
+### Connect Browser
+
+```javascript
+import { chromium } from 'playwright-core';
+
+let browser;
+try {
+  browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+} catch {
+  browser = await chromium.launch({ headless: true });
+}
+```
+
+### Create Snapshot Directory
+
+```bash
+DATE=$(date +%Y-%m-%d)
+SNAPSHOT_DIR=".flowchad/snapshots/${DATE}-reproduce-issue-${ISSUE_NUMBER}"
+mkdir -p "$SNAPSHOT_DIR"
+```
+
+### Execute Steps
+
+For each step in the inferred flow:
+1. Perform the action (navigate, fill, click, wait, scroll)
+2. Record timing
+3. Take screenshot: `step-{N:02d}-{action}.png`
+4. Evaluate the `expect` string against the screenshot + DOM
+5. Capture JavaScript console errors via `page.on('console', ...)` — console errors are additional evidence
+6. Record status: `pass`, `fail`, `error`
+
+**Capture console errors:**
+```javascript
+const consoleErrors = [];
+page.on('console', msg => {
+  if (msg.type() === 'error') {
+    consoleErrors.push({ type: msg.type(), text: msg.text(), ts: Date.now() });
+  }
+});
+page.on('pageerror', err => {
+  consoleErrors.push({ type: 'uncaught', text: err.message, ts: Date.now() });
+});
+```
+
+Add `console_errors` to the step result in `results.json` when present.
+
+### Record Video
+
+```javascript
+const context = await browser.newContext({
+  recordVideo: {
+    dir: SNAPSHOT_DIR,
+    size: { width: 1280, height: 720 }
+  }
+});
+```
+
+Follow flow-walk's smart trim + GIF conversion steps after closing the context.
+
+### Error Matching
+
+After each step, check if visible text or console errors contain the reported error message:
+
+```javascript
+const pageText = await page.textContent('body').catch(() => '');
+const hasErrorMatch = pageText.toLowerCase().includes(ERROR_MESSAGE.toLowerCase())
+  || consoleErrors.some(e => e.text.toLowerCase().includes(ERROR_MESSAGE.toLowerCase()));
+```
+
+Record `error_match: true` in the step result when the reported error is visibly reproduced.
+
+---
+
+## Phase 4: Determine Outcome
+
+### Load Results
+
+Read `results.json` from the snapshot directory. Evaluate:
+
+```javascript
+const steps = results.steps;
+
+const reproduced = steps.some(s =>
+  s.status === 'error'
+  || s.status === 'fail'
+  || s.error_match === true
+) || consoleErrors.some(e =>
+  e.text.toLowerCase().includes(ERROR_MESSAGE.toLowerCase())
+);
+
+const outcome = reproduced ? 'reproduced' : 'could-not-reproduce';
+```
+
+**Reproduced criteria (any one sufficient):**
+- Any step has status `error` or `fail`
+- Any step has `error_match: true` (visible page text or console error matches reported message)
+- The final screenshot shows a visible error page (5xx, "something went wrong", crash dialog)
+
+**Could not reproduce criteria:**
+- All steps passed with no error indicators
+- None of the error patterns from the issue were observed
+
+Save outcome to `results.json`:
+```json
+{
+  "reproduction": {
+    "outcome": "reproduced",
+    "matched_error": "TypeError: Cannot read property 'id' of undefined",
+    "matched_at_step": 3,
+    "console_errors": [...]
+  }
+}
+```
+
+---
+
+## Phase 5: Update GitHub Issue
+
+### Step 5a: Upload Evidence
+
+```bash
+REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|')
+
+# Initialize evidence branch if needed
+bash scripts/evidence-init.sh "$REPO" 2>/dev/null || true
+
+# Upload screenshots
+GIF_URL=""
+for screenshot in "${SNAPSHOT_DIR}"/step-*.png; do
+  [ -f "$screenshot" ] || continue
+  FNAME=$(basename "$screenshot")
+  bash scripts/evidence-upload.sh "$screenshot" "$REPO" \
+    "reproduce-issue-${ISSUE_NUMBER}/${DATE}/${FNAME}" 2>/dev/null || true
+done
+
+# Upload GIF
+if [ -f "${SNAPSHOT_DIR}/reproduce-issue-${ISSUE_NUMBER}.gif" ]; then
+  GIF_URL=$(bash scripts/evidence-upload.sh \
+    "${SNAPSHOT_DIR}/reproduce-issue-${ISSUE_NUMBER}.gif" \
+    "$REPO" \
+    "reproduce-issue-${ISSUE_NUMBER}/${DATE}/reproduce-issue-${ISSUE_NUMBER}.gif" 2>/dev/null) || true
+fi
+```
+
+If evidence upload fails, use local file paths and note in the comment that evidence is local-only.
+
+### Step 5b: Apply Label
+
+```bash
+# Ensure labels exist
+gh label create "reproduced" --repo "$FULL_REPO" \
+  --color "0E8A16" --description "Bug successfully reproduced" 2>/dev/null || true
+gh label create "could-not-reproduce" --repo "$FULL_REPO" \
+  --color "C2E0C6" --description "Could not reproduce the reported bug" 2>/dev/null || true
+
+gh issue edit "$ISSUE_NUMBER" --repo "$FULL_REPO" \
+  --add-label "$outcome"
+```
+
+### Step 5c: Post Structured Comment
+
+Build and post the comment:
+
+**When reproduced:**
+
+```markdown
+## :bug: Reproduced
+
+FlowChad successfully reproduced this bug. Screen recording and steps attached below.
+
+### Steps to Reproduce
+
+| # | Action | Target | Outcome |
+|---|--------|--------|---------|
+| 1 | navigate | {url} | {pass/fail/error} |
+| 2 | {action} | {target} | {status} |
+...
+
+### Error Observed
+
+> {ERROR_MESSAGE}
+
+Matched at step {N}: {screenshot-inline-if-available}
+
+### Evidence
+
+![Reproduction recording]({GIF_URL or local path})
+
+| Field | Value |
+|-------|-------|
+| URL | {AFFECTED_URL} |
+| Base URL | {BASE_URL} |
+| Flow file | `.flowchad/flows/reproduce-issue-{N}.yml` |
+| Snapshot dir | `.flowchad/snapshots/{date}-reproduce-issue-{N}/` |
+| Date | {ISO datetime} |
+| Browser | Chromium (Playwright headless) |
+
+### Next Steps
+
+Run `/flow-walk reproduce-issue-{N}` after your fix to verify it no longer reproduces.
+
+---
+*Posted by FlowChad `/flow-reproduce` — issue #{N}*
+```
+
+**When could not reproduce:**
+
+```markdown
+## :white_check_mark: Could Not Reproduce
+
+FlowChad attempted to reproduce this bug but all steps passed without observing the reported error.
+
+### Steps Attempted
+
+| # | Action | Target | Outcome |
+|---|--------|--------|---------|
+| 1 | navigate | {url} | {status} |
+...
+
+### What Was Tried
+
+- Navigated to: `{AFFECTED_URL}`
+- Triggering action: `{TRIGGERING_ACTION or "not identified — only navigation attempted"}`
+- Auth state: `{AUTH_STATE}`
+- Error searched for: `{ERROR_MESSAGE}`
+
+### Evidence
+
+![Walk recording]({GIF_URL or local path})
+
+| Field | Value |
+|-------|-------|
+| URL | {AFFECTED_URL} |
+| Base URL | {BASE_URL} |
+| Flow file | `.flowchad/flows/reproduce-issue-{N}.yml` |
+| Date | {ISO datetime} |
+| Browser | Chromium (Playwright headless) |
+
+### Possible Reasons
+
+1. Bug requires specific user data or database state not present in the test environment
+2. Auth credentials not configured — bug may only occur in authenticated sessions
+3. Timing/race condition — try running the flow manually: `/flow-walk reproduce-issue-{N}`
+4. Environment-specific — bug may only occur on a specific OS/browser/screen size
+5. Bug was already fixed in the current codebase
+
+---
+*Posted by FlowChad `/flow-reproduce` — issue #{N}*
+```
+
+Post the comment:
+```bash
+gh issue comment "$ISSUE_NUMBER" --repo "$FULL_REPO" --body "$COMMENT_BODY"
+```
+
+### Step 5d: Handle Unavailable GitHub Auth
+
+If `gh issue comment` fails (no auth, no network), print the full comment body to stdout so the user can post it manually:
+
+```
+[flowchad] GitHub auth unavailable — copy and paste the following comment manually:
+
+---
+{COMMENT_BODY}
+---
+
+Label to apply: {outcome}
+```
+
+---
+
+## Output Summary
+
+After the full flow completes:
+
+```
+## Flow Reproduce: issue #{N}
+
+Outcome: REPRODUCED ✗  (or  COULD NOT REPRODUCE ✓)
+Steps:   {passed}/{total} passed
+GIF:     {path or URL}
+Label:   {outcome} applied to {ISSUE_URL}
+Comment: {comment_url}
+
+Flow saved: .flowchad/flows/reproduce-issue-{N}.yml
+Snapshot:   .flowchad/snapshots/{date}-reproduce-issue-{N}/
+
+Next: run /flow-walk reproduce-issue-{N} after the fix to verify it no longer reproduces.
+```
+
+If a GIF was generated, display it inline (Read the GIF file — it renders in Claude Code and VS Code).
+
+---
+
+## Graceful Degradation
+
+| Failure | Behavior |
+|---------|----------|
+| Browser unavailable (no Playwright, no Chrome) | Print "could not start browser" error, post `could-not-reproduce` comment with error message, exit |
+| URL cannot be inferred | Ask user for URL before proceeding |
+| GitHub auth unavailable | Print label + comment for manual application, save results locally |
+| Evidence upload fails | Continue without evidence URLs, use local paths in comment |
+| Issue is already CLOSED | Post comment noting issue is closed, skip label change |
+| Walk errors on first step (navigation fails) | Record error, continue to observation step, report `error` outcome |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ specs/                        # Accepted feature specs
 QUALITY_SCORE.md              # Per-skill quality grades and open issues
 ```
 
-## The Nine Skills
+## The Ten Skills
 
 | Command | What it does |
 |---------|-------------|
@@ -35,6 +35,7 @@ QUALITY_SCORE.md              # Per-skill quality grades and open issues
 | `/flow-suggest <name>` | Prioritized improvement plan ranked by effort vs impact |
 | `/flow-diff <name>` | Compares walk snapshots across time to detect regressions |
 | `/flow-diagram <name>` | Generates Mermaid flowchart from a flow definition |
+| `/flow-reproduce <issue-ref>` | Reproduces a customer-reported bug in-browser, attaches evidence to the GitHub issue |
 | `/evidence-upload` | Uploads screenshots/GIFs to configured evidence backend |
 
 ## Key Rules

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -15,6 +15,7 @@ Last updated: 2026-05-25
 | flow-diagram | B | 2026-05-21 | S1 ✅, S3 ✅, S4 ✅ (2 open), S6 ❌ |
 | flow-update | C | 2026-05-21 | S1 ✅, S3 ✅, S4 ⚠️ (4 open), S6 ❌ |
 | evidence-upload | B | 2026-05-21 | S1 ✅, S3 ✅, S4 ✅ (0 open), S6 ❌ |
+| flow-reproduce | B | 2026-05-25 | S1 ✅, S3 ✅ (new — same day), S4 ✅ (0 open), S6 ❌ |
 
 ## Signal Matrix
 
@@ -29,12 +30,13 @@ Last updated: 2026-05-25
 | flow-diagram | ✅ | N/A | ✅ (docs>code) | ✅ (2) | N/A | ❌ |
 | flow-update | ✅ | N/A | ✅ (docs>code) | ⚠️ (4) | N/A | ❌ |
 | evidence-upload | ✅ | N/A | ✅ (docs>code) | ✅ (0) | N/A | ❌ |
+| flow-reproduce | ✅ | N/A | ✅ (new 2026-05-25) | ✅ (0) | N/A | ❌ |
 
 ## Signal Applicability
 
 | Signal | Applicable? | Reason |
 |--------|------------|--------|
-| S1 Doc Coverage | Yes | README.md covers all 9 domains with descriptions and quick-start |
+| S1 Doc Coverage | Yes | README.md covers all 10 domains with descriptions and quick-start |
 | S2 FlowChad | No | Tool repo — no frontend framework; .flowchad/flows/ is empty by design (template) |
 | S3 Staleness | Yes | README last updated 2026-05-01; scripts last commit 2026-05-21 (PR #39 — update mechanism) ✅ |
 | S4 Open Issues | Yes | 6 total open issues across repo |
@@ -44,7 +46,7 @@ Last updated: 2026-05-25
 ## Grade Summary
 
 - A: 0
-- B: 5 (flowchad-setup, flow-suggest, flow-diff, flow-diagram, evidence-upload)
+- B: 6 (flowchad-setup, flow-suggest, flow-diff, flow-diagram, evidence-upload, flow-reproduce)
 - C: 4 (flow-walk, flow-report, flow-add, flow-update)
 - D: 0
 
@@ -64,3 +66,4 @@ Last updated: 2026-05-25
 | 2026-05-21 | daily sweep | 9 domains, 0 regressions, 0 improvements. Dispatched #20 (P1, update mechanism). |
 | 2026-05-21 | PR #39 double-check | Updated S3 staleness for flowchad-setup (scripts updated). #20 6/7 items in PR; "Register on skills.sh registry" remains open. |
 | 2026-05-25 | daily sweep | 9 domains, 0 regressions, 0 improvements. S3 4d ✅. WIP=0. Dispatched #28 (P1, customer bug reproduction). |
+| 2026-05-25 | issue #28 | 10 domains. Added flow-reproduce (B). 0 regressions to existing skills. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,7 @@ skills:
   - flow-diff
   - flow-diagram
   - flow-report
+  - flow-reproduce
   - evidence-upload
 ---
 
@@ -42,6 +43,7 @@ npx skills add Fellowship-dev/flowchad --skill '*'
 | `/flow-suggest <name>` | Prioritized improvement plan ranked by effort vs impact |
 | `/flow-diff <name>` | Compares walk snapshots across time to detect regressions |
 | `/flow-diagram <name>` | Generates Mermaid flowchart from a flow definition |
+| `/flow-reproduce <issue-ref>` | Reproduces a customer-reported bug in-browser, attaches evidence to the GitHub issue |
 | `/evidence-upload` | Uploads screenshots/GIFs to configured evidence backend |
 
 ## Update

--- a/reports/2026-05-25-speckit-issue-28.md
+++ b/reports/2026-05-25-speckit-issue-28.md
@@ -1,0 +1,65 @@
+# Pre-Flight Report — Issue #28: Customer Bug Reproduction from Error Reports
+
+**Source issue:** https://github.com/fellowship-dev/flowchad/issues/28
+**Date:** 2026-05-25
+**Repo:** /efs/missions/repos/fellowship-dev-flowchad-issue28
+
+---
+
+## Issue Summary
+
+Given a support ticket or error report (Bugsnag, Sentry, customer email), FlowChad should attempt to reproduce the bug in-browser, producing a screen recording + structured steps-to-reproduce, then attach evidence and label the original GitHub issue.
+
+## Open Questions — Resolved
+
+| Question | Resolution |
+|----------|-----------|
+| Trigger: manual or auto on `bugsnag` label? | **Manual dispatch** — `/flow-reproduce <issue-ref>`. Auto-trigger can be a follow-on; manual is safer first. |
+| Browser context: needs auth? | **Use config.yml credentials** if issue mentions authenticated flow; otherwise anonymous. Skill will prompt user to set credentials if needed. |
+| Scope: frontend or API too? | **Frontend-first** (Playwright). API responses checked via `page.evaluate()` inside expect assertions where relevant. |
+
+## What Needs Building
+
+A new 10th skill: **`/flow-reproduce`**
+
+### Input
+- GitHub issue reference (URL or `owner/repo#number` or just `number` if default repo configured)
+- Issue contains: error message, stack trace, user action description, URL
+
+### Behavior
+1. Fetch the issue from GitHub API
+2. Parse error context: error class, message, URL, user action, stack trace hints
+3. Infer a reproduction flow YAML from the error context
+4. Execute the flow using existing flow-walk logic (Playwright CDP)
+5. Capture screenshots + video at each step
+6. Determine if bug is reproduced (Critical findings in walk) or not
+7. Update the original issue with:
+   - Label: `reproduced` or `could-not-reproduce`
+   - Comment with structured steps-to-reproduce + GIF evidence
+
+### New Files
+- `.flowchad/skills/flow-reproduce/SKILL.md` — the skill implementation
+- `.flowchad/commands/flow-reproduce.md` — command shortcut
+
+### Integration Points
+- Uses `flow-walk` execution model (Step 1-4 of that skill)
+- Uses `evidence-upload` for screenshots/GIF
+- Uses `flow-add` inference logic (Step 1-2) to build the flow
+- Labels applied via `gh issue edit`
+- Comment posted via `gh issue comment`
+
+## Codebase Patterns Observed
+
+- All skills live at `.flowchad/skills/{name}/SKILL.md`
+- All commands live at `.flowchad/commands/{name}.md`
+- Commands are thin wrappers that reference the skill
+- Skills are fully self-contained AI execution specs (markdown)
+- No test infrastructure exists (confirmed in QUALITY_SCORE.md — S5 N/A)
+- All bash in skills uses POSIX-portable syntax
+- Evidence upload uses `scripts/evidence-upload.sh`
+
+## Risk Assessment
+
+**Low risk:** Adding a new skill file doesn't modify existing skills or scripts.
+**Medium complexity:** Parsing error context from free-text GitHub issues (stack traces, Bugsnag payloads, plain descriptions).
+**Existing leverage:** flow-walk, evidence-upload, flow-add all cover the core execution model — flow-reproduce mainly orchestrates them.

--- a/specs/28/plan.md
+++ b/specs/28/plan.md
@@ -1,0 +1,81 @@
+# Plan: flow-reproduce skill (issue #28)
+
+## Approach
+
+Add a single new skill file + command wrapper. No existing files modified except QUALITY_SCORE.md and SKILL.md (readme). Zero risk to existing skill behavior.
+
+## Implementation Steps
+
+### 1. Create `.flowchad/skills/flow-reproduce/SKILL.md`
+
+The skill spec has five phases:
+
+**Phase 1 — Parse issue context**
+- Accept `<issue-ref>`: bare number, `owner/repo#N`, or full GitHub URL
+- `gh issue view` to fetch title, body, comments as JSON
+- Extract from free text:
+  - Error message (grep for "Error:", "Exception:", Bugsnag `error_class`)
+  - Affected URL (grep for `https?://`, route patterns `/path/...`)
+  - Triggering action (keywords: "click", "submit", "navigate", "scroll", "load")
+  - Auth state (keywords: "logged in", "authenticated", "signed in" vs "logged out")
+- If URL cannot be extracted, ask user before proceeding
+
+**Phase 2 — Infer reproduction flow**
+- Build minimal YAML with steps to reach the error
+- Steps always start with `navigate` to the affected URL
+- Add a step for the triggering action if identified
+- Add a `wait` step to observe the result
+- Save to `.flowchad/flows/reproduce-issue-{N}.yml`
+- Show inferred flow to user with "Proceeding with this flow..." (no blocking confirm — auto-proceed for CI friendliness)
+
+**Phase 3 — Walk the flow**
+- Reuse flow-walk execution model exactly
+- Launch/connect browser, execute steps, capture screenshots + video
+- Catch errors per step, continue (don't abort)
+- Smart trim video + GIF conversion
+
+**Phase 4 — Determine outcome**
+- Reproduced if: any step status is `error` or `fail`
+  OR page HTML contains error indicators (500, "something went wrong", stack trace text, Bugsnag widget)
+- Could not reproduce otherwise
+- Save results to `.flowchad/snapshots/{date}-reproduce-issue-{N}/results.json`
+
+**Phase 5 — Update GitHub issue**
+- Upload evidence via `scripts/evidence-upload.sh`
+- Apply label via `gh issue edit --add-label reproduced` or `could-not-reproduce`
+- Post structured comment via `gh issue comment`
+- Comment template: outcome header + steps table + evidence inline
+
+### 2. Create `.flowchad/commands/flow-reproduce.md`
+
+Thin command: describes usage, links to SKILL.md.
+
+### 3. Update `QUALITY_SCORE.md`
+
+Add `flow-reproduce` row (initial grade B: S1 ✅, S4 ✅ (0 open), S6 ❌).
+
+### 4. Update repo-root `SKILL.md` (README)
+
+Add `/flow-reproduce` to the skills table.
+
+## File Changes Summary
+
+| File | Action |
+|------|--------|
+| `.flowchad/skills/flow-reproduce/SKILL.md` | **Create** (primary deliverable) |
+| `.flowchad/commands/flow-reproduce.md` | **Create** |
+| `QUALITY_SCORE.md` | **Update** (add domain row) |
+| `SKILL.md` | **Update** (add to skills table) |
+
+## No Changes To
+
+- Existing skill files (flow-walk, flow-report, flow-add, etc.)
+- Scripts (no new bash needed — skill orchestrates via existing scripts)
+- config.yml template (no new config keys needed)
+
+## Constraints
+
+- Portable bash only in any inline bash (no bash 4+ features)
+- Use `$ENV_VAR` references for credentials, never hardcoded
+- Skill spec must be fully self-contained (AI executes from markdown only)
+- Graceful degradation if browser or GitHub auth unavailable

--- a/specs/28/spec.md
+++ b/specs/28/spec.md
@@ -1,0 +1,77 @@
+# Spec: Customer bug reproduction from error reports (issue #28)
+
+## Problem Statement
+
+Support engineers and developers receive bug reports via Bugsnag, Sentry, customer emails, or internal tickets. Today, reproducing those bugs requires:
+1. Reading the error report
+2. Manually setting up a browser session
+3. Navigating to the affected page
+4. Attempting to trigger the same conditions
+
+This is slow, inconsistent, and often skipped — leading to PRs that fix the wrong thing or miss the root cause entirely. FlowChad already has the infrastructure to walk user flows in-browser and capture evidence. Issue #28 asks us to apply that infrastructure to bug reproduction.
+
+## Acceptance Criteria
+
+1. **`/flow-reproduce <issue-ref>`** is a valid FlowChad command that accepts a GitHub issue reference (URL, `owner/repo#N`, or bare `N` with configured default repo).
+
+2. The skill fetches the issue body and comments from GitHub, then parses the following from the error context:
+   - Error class and message (from Bugsnag/Sentry payloads or plain text)
+   - Affected URL or route (where the error occurred)
+   - User action that triggered the error (click, form submit, navigation)
+   - Stack trace hints (method/file for context, not executed)
+   - Auth state (logged in vs anonymous, inferred from context)
+
+3. The skill infers a **reproduction flow YAML** from the parsed context — a minimal set of steps to navigate to the error, perform the triggering action, and observe the result.
+
+4. The inferred flow is walked in-browser using the existing Playwright CDP execution model (same as `flow-walk`). Screenshots and video are captured.
+
+5. After the walk, the skill determines the reproduction outcome:
+   - **Reproduced**: at least one step returned `error` or `fail`, OR the page shows visible error indicators matching the report
+   - **Could not reproduce**: all steps passed with no error indicators matching the report
+
+6. The original GitHub issue is updated with:
+   - Label `reproduced` or `could-not-reproduce` applied via `gh issue edit`
+   - A structured comment containing:
+     - Reproduction outcome header
+     - Steps attempted (numbered, matching the inferred flow)
+     - Evidence: screenshot + GIF embedded inline
+     - Environment context (URL, browser, date)
+
+7. The inferred flow YAML is saved to `.flowchad/flows/reproduce-issue-{N}.yml` so it can be re-run after a fix attempt.
+
+8. The skill handles graceful degradation:
+   - If no URL can be inferred from the issue, it asks the user before proceeding
+   - If the walk itself errors (browser unavailable), it documents what was attempted and posts a `could-not-reproduce` comment with the error
+   - If GitHub auth is unavailable, it writes results locally and prints the comment text for manual posting
+
+## Skill Files
+
+### New: `.flowchad/skills/flow-reproduce/SKILL.md`
+Full skill implementation. Covers: parsing, flow inference, walk execution, outcome determination, issue update.
+
+### New: `.flowchad/commands/flow-reproduce.md`
+Thin command wrapper pointing to the skill.
+
+### Modified: `QUALITY_SCORE.md`
+Add `flow-reproduce` domain row once skill ships.
+
+### Modified: `README.md` (SKILL.md at repo root)
+Add `/flow-reproduce` to the nine (now ten) skills table.
+
+## Non-Goals
+
+- Automatic trigger on `bugsnag` label (follow-on issue; manual dispatch is v1)
+- Reproducing bugs that require specific database state or seed data
+- Multi-step auth flows with OAuth/SSO (future: Navvi persona)
+- API-only bugs with no browser-observable symptom (flow-reproduce is browser-first)
+- Modifying or closing the source issue — only add label + comment
+
+## Design Decisions
+
+**Why save the flow YAML?** So the fix author can re-run `/flow-walk reproduce-issue-28` after their change to verify the fix. The flow becomes a regression test artifact.
+
+**Why `could-not-reproduce` instead of silence?** Silence creates ambiguity — was it reproduced and missed, or never attempted? An explicit label and comment prevents wasted investigation.
+
+**Why use existing `flow-walk` execution model?** Re-use over re-implementation. flow-walk's error handling (catch errors, continue, take screenshot) is exactly what reproduction needs.
+
+**Trigger design (manual v1):** Auto-trigger on `bugsnag` label has race conditions (issue created before Bugsnag body is appended). Manual dispatch avoids this and lets the user verify the inferred flow before it runs.

--- a/specs/28/tasks.md
+++ b/specs/28/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: flow-reproduce skill (issue #28)
+
+## Task 1 — Create `.flowchad/skills/flow-reproduce/SKILL.md`
+
+Primary deliverable. Full skill spec covering all five phases:
+- Phase 1: Parse issue context (gh issue view, extract error/URL/action/auth)
+- Phase 2: Infer reproduction flow YAML and save to `.flowchad/flows/`
+- Phase 3: Walk flow using Playwright CDP (reuse flow-walk model)
+- Phase 4: Determine outcome (reproduced vs could-not-reproduce)
+- Phase 5: Upload evidence + update GitHub issue (label + comment)
+
+Acceptance: skill is self-contained, covers all phases, handles graceful degradation.
+
+## Task 2 — Create `.flowchad/commands/flow-reproduce.md`
+
+Thin command wrapper. Usage line, link to skill, example invocations.
+Mirrors the pattern in `.flowchad/commands/flow-walk.md`.
+
+## Task 3 — Update `QUALITY_SCORE.md`
+
+Add `flow-reproduce` domain row to the Domains table and Signal Matrix.
+Update "History" entry for today (2026-05-25).
+Update grade summary counts.
+
+## Task 4 — Update `SKILL.md` (repo root README)
+
+Add `/flow-reproduce` row to the skills table (The Nine Skills → The Ten Skills section).
+Update the skill count from nine to ten in text references.


### PR DESCRIPTION
## Summary

- Adds a new 10th skill `/flow-reproduce <issue-ref>` that reproduces customer-reported bugs in-browser
- Accepts GitHub issue references (bare number, `owner/repo#N`, or full URL)
- Parses error context from issue body + comments (error message, affected URL, triggering action, auth state, stack trace hints)
- Infers a minimal Playwright reproduction flow, walks it headlessly, captures screenshots + GIF
- Labels the source issue `reproduced` or `could-not-reproduce` and posts a structured evidence comment
- Saves the inferred flow to `.flowchad/flows/reproduce-issue-{N}.yml` for re-running after a fix

## Changes

| File | Action |
|------|--------|
| `.flowchad/skills/flow-reproduce/SKILL.md` | New skill — 5-phase spec: parse → infer flow → walk → determine outcome → update issue |
| `.flowchad/commands/flow-reproduce.md` | New command wrapper |
| `CLAUDE.md` | Updated skills table (Nine → Ten Skills) |
| `SKILL.md` | Added `/flow-reproduce` to skill list + frontmatter |
| `QUALITY_SCORE.md` | Added `flow-reproduce` domain row (grade B, 0 open issues) |
| `specs/28/` | Speckit spec, plan, and tasks |

## Design Decisions

- **Manual dispatch (v1)**: `/flow-reproduce 42` rather than auto-trigger on `bugsnag` label — avoids race conditions where issue is created before Bugsnag appends the body
- **Saves flow YAML**: inferred flow becomes a reusable regression test — fix author runs `/flow-walk reproduce-issue-42` to verify
- **`could-not-reproduce` is explicit**: always posts a comment so the team knows what was tried, even when reproduction fails
- **Graceful degradation**: handles missing browser, missing GitHub auth, and unresolvable URLs without hard failures

## Test plan

- [ ] Run `/flow-reproduce 28` on this repo to verify the command resolves and prints an inferred flow
- [ ] Verify `.flowchad/flows/reproduce-issue-28.yml` is created after invocation
- [ ] Verify label `reproduced` or `could-not-reproduce` is applied to source issue
- [ ] Verify comment is posted with steps table + evidence inline

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)